### PR TITLE
fix: support multiple http verbs for rate limiting

### DIFF
--- a/clients/aplus-content-api-2020-11-01/src/client.ts
+++ b/clients/aplus-content-api-2020-11-01/src/client.ts
@@ -1,57 +1,67 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, AplusContentApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {AplusContentApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*/asins$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*/asins$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentAsinValidations$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentPublishRecords$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*/approvalSubmissions$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/aplus/2020-11-01/contentDocuments/[^/]*/suspendSubmissions$'),
     rate: 10,
     burst: 10

--- a/clients/authorization-api-v1/src/client.ts
+++ b/clients/authorization-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, AuthorizationApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {AuthorizationApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/authorization/v1/authorizationCode$'),
     rate: 1,
     burst: 5

--- a/clients/catalog-items-api-2020-12-01/src/client.ts
+++ b/clients/catalog-items-api-2020-12-01/src/client.ts
@@ -1,17 +1,19 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, CatalogApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {CatalogItemsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/catalog/2020-12-01/items$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/catalog/2020-12-01/items/[^/]*$'),
     rate: 5,
     burst: 5

--- a/clients/catalog-items-api-v0/src/client.ts
+++ b/clients/catalog-items-api-v0/src/client.ts
@@ -1,22 +1,25 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, CatalogApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {CatalogItemsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/catalog/v0/items$'),
     rate: 6,
     burst: 40
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/catalog/v0/items/[^/]*$'),
     rate: 2,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/catalog/v0/categories$'),
     rate: 1,
     burst: 40

--- a/clients/fba-inbound-eligibility-api-v1/src/client.ts
+++ b/clients/fba-inbound-eligibility-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FbaInboundApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FbaInboundEligibilityApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v1/eligibility/itemPreview$'),
     rate: 1,
     burst: 1

--- a/clients/fba-inventory-api-v1/src/client.ts
+++ b/clients/fba-inventory-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FbaInventoryApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FbaInventoryApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inventory/v1/summaries$'),
     rate: 90,
     burst: 150

--- a/clients/fba-small-and-light-api-v1/src/client.ts
+++ b/clients/fba-small-and-light-api-v1/src/client.ts
@@ -1,32 +1,37 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, SmallAndLightApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FbaSmallAndLightApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/smallAndLight/v1/enrollments/[^/]*$'),
     rate: 2,
     burst: 10
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/smallAndLight/v1/enrollments/[^/]*$'),
     rate: 2,
     burst: 5
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/fba/smallAndLight/v1/enrollments/[^/]*$'),
     rate: 2,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/smallAndLight/v1/eligibilities/[^/]*$'),
     rate: 2,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/smallAndLight/v1/feePreviews$'),
     rate: 1,
     burst: 3

--- a/clients/feeds-api-2020-09-04/src/client.ts
+++ b/clients/feeds-api-2020-09-04/src/client.ts
@@ -1,37 +1,43 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FeedsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FeedsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2020-09-04/feeds$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/feeds/2020-09-04/feeds$'),
     rate: 0.0083,
     burst: 15
   },
   {
-    urlRegex: new RegExp('^/feeds/2020-09-04/feeds/[^/]*$'),
-    rate: 0.0222,
-    burst: 10
-  },
-  {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2020-09-04/feeds/[^/]*$'),
     rate: 2,
     burst: 15
   },
   {
+    method: 'delete',
+    urlRegex: new RegExp('^/feeds/2020-09-04/feeds/[^/]*$'),
+    rate: 0.0222,
+    burst: 10
+  },
+  {
+    method: 'post',
     urlRegex: new RegExp('^/feeds/2020-09-04/documents$'),
     rate: 0.0083,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2020-09-04/documents/[^/]*$'),
     rate: 0.0222,
     burst: 10

--- a/clients/feeds-api-2021-06-30/src/client.ts
+++ b/clients/feeds-api-2021-06-30/src/client.ts
@@ -1,37 +1,43 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FeedsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FeedsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2021-06-30/feeds$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/feeds/2021-06-30/feeds$'),
     rate: 0.0083,
     burst: 15
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/feeds/2021-06-30/feeds/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2021-06-30/feeds/[^/]*$'),
     rate: 2,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/feeds/2021-06-30/documents$'),
     rate: 0.0083,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/feeds/2021-06-30/documents/[^/]*$'),
     rate: 0.0222,
     burst: 10

--- a/clients/finances-api-v0/src/client.ts
+++ b/clients/finances-api-v0/src/client.ts
@@ -1,27 +1,31 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, DefaultApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FinancesApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/finances/v0/financialEventGroups$'),
     rate: 0.5,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/finances/v0/financialEventGroups/[^/]*/financialEvents$'),
     rate: 0.5,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/finances/v0/orders/[^/]*/financialEvents$'),
     rate: 0.5,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/finances/v0/financialEvents$'),
     rate: 0.5,
     burst: 30

--- a/clients/fulfillment-inbound-api-v0/src/client.ts
+++ b/clients/fulfillment-inbound-api-v0/src/client.ts
@@ -1,92 +1,109 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FbaInboundApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FulfillmentInboundApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/itemsGuidance$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/inbound/v0/plans$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/preorder$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/preorder/confirm$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/prepInstructions$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/transport$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/transport$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/transport/void$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/transport/estimate$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/transport/confirm$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/labels$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/billOfLading$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipments/[^/]*/items$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/inbound/v0/shipmentItems$'),
     rate: 2,
     burst: 30

--- a/clients/fulfillment-outbound-api-2020-07-01/src/client.ts
+++ b/clients/fulfillment-outbound-api-2020-07-01/src/client.ts
@@ -1,67 +1,79 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FbaOutboundApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {FulfillmentOutboundApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders/preview$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/tracking$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/returnReasonCodes$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders/[^/]*/return$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders/[^/]*$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders/[^/]*$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/fulfillmentOrders/[^/]*/cancel$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/features$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/features/inventory/[^/]*$'),
     rate: 2,
     burst: 30
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/2020-07-01/features/inventory/[^/]*$'),
     rate: 2,
     burst: 30

--- a/clients/listings-items-api-2020-09-01/src/client.ts
+++ b/clients/listings-items-api-2020-09-01/src/client.ts
@@ -1,22 +1,25 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ListingsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ListingsItemsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'delete',
     urlRegex: new RegExp('^/listings/2020-09-01/items/[^/]*$'),
     rate: 5,
     burst: 10
   },
   {
+    method: 'patch',
     urlRegex: new RegExp('^/listings/2020-09-01/items/[^/]*$'),
     rate: 5,
     burst: 10
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/listings/2020-09-01/items/[^/]*$'),
     rate: 5,
     burst: 10

--- a/clients/merchant-fulfillment-api-v0/src/client.ts
+++ b/clients/merchant-fulfillment-api-v0/src/client.ts
@@ -1,47 +1,55 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, MerchantFulfillmentApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {MerchantFulfillmentApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/mfn/v0/eligibleServices$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/mfn/v0/eligibleShippingServices$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/mfn/v0/shipments/[^/]*$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/mfn/v0/shipments/[^/]*$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/mfn/v0/shipments/[^/]*/cancel$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/mfn/v0/shipments$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/mfn/v0/sellerInputs$'),
     rate: 1,
     burst: 1
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/mfn/v0/additionalSellerInputs$'),
     rate: 1,
     burst: 1

--- a/clients/messaging-api-v1/src/client.ts
+++ b/clients/messaging-api-v1/src/client.ts
@@ -1,67 +1,79 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, MessagingApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {MessagingApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/confirmCustomizationDetails$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/confirmDeliveryDetails$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/legalDisclosure$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/negativeFeedbackRemoval$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/confirmOrderDetails$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/confirmServiceDetails$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/amazonMotors$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/warranty$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/attributes$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/digitalAccessKey$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/messaging/v1/orders/[^/]*/messages/unexpectedProblem$'),
     rate: 1,
     burst: 5

--- a/clients/notifications-api-v1/src/client.ts
+++ b/clients/notifications-api-v1/src/client.ts
@@ -1,47 +1,55 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, NotificationsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {NotificationsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/notifications/v1/subscriptions/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/notifications/v1/subscriptions/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/notifications/v1/subscriptions/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/notifications/v1/subscriptions/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/notifications/v1/destinations$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/notifications/v1/destinations$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/notifications/v1/destinations/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/notifications/v1/destinations/[^/]*$'),
     rate: 1,
     burst: 5

--- a/clients/orders-api-v0/src/client.ts
+++ b/clients/orders-api-v0/src/client.ts
@@ -1,37 +1,43 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, OrdersV0Api} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {OrdersApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders$'),
     rate: 0.0055,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders/[^/]*$'),
     rate: 0.0055,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders/[^/]*/buyerInfo$'),
     rate: 0.0055,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders/[^/]*/address$'),
     rate: 0.0055,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders/[^/]*/orderItems$'),
     rate: 0.0055,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/orders/v0/orders/[^/]*/orderItems/buyerInfo$'),
     rate: 0.0055,
     burst: 20

--- a/clients/product-fees-api-v0/src/client.ts
+++ b/clients/product-fees-api-v0/src/client.ts
@@ -1,17 +1,19 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, FeesApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ProductFeesApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/products/fees/v0/listings/[^/]*/feesEstimate$'),
     rate: 10,
     burst: 20
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/products/fees/v0/items/[^/]*/feesEstimate$'),
     rate: 10,
     burst: 20

--- a/clients/product-pricing-api-v0/src/client.ts
+++ b/clients/product-pricing-api-v0/src/client.ts
@@ -1,27 +1,31 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ProductPricingApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ProductPricingApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/products/pricing/v0/price$'),
     rate: 10,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/products/pricing/v0/competitivePrice$'),
     rate: 10,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/products/pricing/v0/listings/[^/]*/offers$'),
     rate: 5,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/products/pricing/v0/items/[^/]*/offers$'),
     rate: 5,
     burst: 10

--- a/clients/product-type-definitions-api-2020-09-01/src/client.ts
+++ b/clients/product-type-definitions-api-2020-09-01/src/client.ts
@@ -1,17 +1,19 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, DefinitionsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ProductTypeDefinitionsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/definitions/2020-09-01/productTypes$'),
     rate: 5,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/definitions/2020-09-01/productTypes/[^/]*$'),
     rate: 5,
     burst: 10

--- a/clients/reports-api-2020-09-04/src/client.ts
+++ b/clients/reports-api-2020-09-04/src/client.ts
@@ -1,52 +1,61 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ReportsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ReportsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2020-09-04/reports$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/reports/2020-09-04/reports$'),
     rate: 0.0167,
     burst: 15
   },
   {
-    urlRegex: new RegExp('^/reports/2020-09-04/reports/[^/]*$'),
-    rate: 0.0222,
-    burst: 10
-  },
-  {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2020-09-04/reports/[^/]*$'),
     rate: 2,
     burst: 15
   },
   {
+    method: 'delete',
+    urlRegex: new RegExp('^/reports/2020-09-04/reports/[^/]*$'),
+    rate: 0.0222,
+    burst: 10
+  },
+  {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2020-09-04/schedules$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/reports/2020-09-04/schedules$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2020-09-04/schedules/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/reports/2020-09-04/schedules/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2020-09-04/documents/[^/]*$'),
     rate: 0.0167,
     burst: 15

--- a/clients/reports-api-2021-06-30/src/client.ts
+++ b/clients/reports-api-2021-06-30/src/client.ts
@@ -1,52 +1,61 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ReportsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ReportsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2021-06-30/reports$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/reports/2021-06-30/reports$'),
     rate: 0.0167,
     burst: 15
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/reports/2021-06-30/reports/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2021-06-30/reports/[^/]*$'),
     rate: 2,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2021-06-30/schedules$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/reports/2021-06-30/schedules$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'delete',
     urlRegex: new RegExp('^/reports/2021-06-30/schedules/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2021-06-30/schedules/[^/]*$'),
     rate: 0.0222,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/reports/2021-06-30/documents/[^/]*$'),
     rate: 0.0167,
     burst: 15

--- a/clients/sales-api-v1/src/client.ts
+++ b/clients/sales-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, SalesApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {SalesApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/sales/v1/orderMetrics$'),
     rate: 0.5,
     burst: 15

--- a/clients/sellers-api-v1/src/client.ts
+++ b/clients/sellers-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, SellersApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {SellersApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/sellers/v1/marketplaceParticipations$'),
     rate: 0.016,
     burst: 15

--- a/clients/services-api-v1/src/client.ts
+++ b/clients/services-api-v1/src/client.ts
@@ -1,37 +1,43 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ServiceApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ServicesApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/service/v1/serviceJobs/[^/]*$'),
     rate: 20,
     burst: 40
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/service/v1/serviceJobs/[^/]*/cancellations$'),
     rate: 5,
     burst: 20
   },
   {
+    method: 'put',
     urlRegex: new RegExp('^/service/v1/serviceJobs/[^/]*/completions$'),
     rate: 5,
     burst: 20
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/service/v1/serviceJobs$'),
     rate: 10,
     burst: 40
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/service/v1/serviceJobs/[^/]*/appointments$'),
     rate: 5,
     burst: 20
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/service/v1/serviceJobs/[^/]*$'),
     rate: 5,
     burst: 20

--- a/clients/shipment-invoicing-api-v0/src/client.ts
+++ b/clients/shipment-invoicing-api-v0/src/client.ts
@@ -1,22 +1,25 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ShipmentInvoiceApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ShipmentInvoicingApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/brazil/v0/shipments/[^/]*$'),
     rate: 1.133,
     burst: 25
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/fba/outbound/brazil/v0/shipments/[^/]*/invoice$'),
     rate: 1.133,
     burst: 25
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/fba/outbound/brazil/v0/shipments/[^/]*/invoice/status$'),
     rate: 1.133,
     burst: 25

--- a/clients/shipping-api-v1/src/client.ts
+++ b/clients/shipping-api-v1/src/client.ts
@@ -1,52 +1,61 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, ShippingApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {ShippingApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/shipments$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/shipping/v1/shipments/[^/]*$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/shipments/[^/]*/cancel$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/shipments/[^/]*/purchaseLabels$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/shipments/[^/]*/label$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/purchaseShipment$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/shipping/v1/rates$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/shipping/v1/account$'),
     rate: 5,
     burst: 15
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/shipping/v1/tracking/[^/]*$'),
     rate: 1,
     burst: 1

--- a/clients/solicitations-api-v1/src/client.ts
+++ b/clients/solicitations-api-v1/src/client.ts
@@ -1,17 +1,19 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, SolicitationsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {SolicitationsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/solicitations/v1/orders/[^/]*$'),
     rate: 1,
     burst: 5
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/solicitations/v1/orders/[^/]*/solicitations/productReviewAndSellerFeedback$'),
     rate: 1,
     burst: 5

--- a/clients/tokens-api-2021-03-01/src/client.ts
+++ b/clients/tokens-api-2021-03-01/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, TokensApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {TokensApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/tokens/2021-03-01/restrictedDataToken$'),
     rate: 1,
     burst: 10

--- a/clients/uploads-api-2020-11-01/src/client.ts
+++ b/clients/uploads-api-2020-11-01/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, UploadsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {UploadsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/uploads/2020-11-01/uploadDestinations/[^/]*$'),
     rate: 0.1,
     burst: 5

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/src/client.ts
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, UpdateInventoryApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorDirectFulfillmentInventoryApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/inventory/v1/warehouses/[^/]*/items$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-direct-fulfillment-orders-api-v1/src/client.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/src/client.ts
@@ -1,22 +1,25 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorOrdersApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorDirectFulfillmentOrdersApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/orders/v1/purchaseOrders$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/orders/v1/purchaseOrders/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/orders/v1/acknowledgements$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-direct-fulfillment-payments-api-v1/src/client.ts
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorInvoiceApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorDirectFulfillmentPaymentsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/payments/v1/invoices$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/src/client.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/src/client.ts
@@ -1,52 +1,61 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorShippingLabelsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorDirectFulfillmentShippingApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/shippingLabels$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/shippingLabels$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/shippingLabels/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/shipmentConfirmations$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/shipmentStatusUpdates$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/customerInvoices$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/customerInvoices/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/packingSlips$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/shipping/v1/packingSlips/[^/]*$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/src/client.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorTransactionApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorDirectFulfillmentTransactionsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/directFulfillment/transactions/v1/transactions/[^/]*$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-invoices-api-v1/src/client.ts
+++ b/clients/vendor-invoices-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorPaymentsApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorInvoicesApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/payments/v1/invoices$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-orders-api-v1/src/client.ts
+++ b/clients/vendor-orders-api-v1/src/client.ts
@@ -1,27 +1,31 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorOrdersApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorOrdersApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/orders/v1/purchaseOrders$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/orders/v1/purchaseOrders/[^/]*$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/orders/v1/acknowledgements$'),
     rate: 10,
     burst: 10
   },
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/orders/v1/purchaseOrdersStatus$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-shipments-api-v1/src/client.ts
+++ b/clients/vendor-shipments-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorShippingApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorShipmentsApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'post',
     urlRegex: new RegExp('^/vendor/shipping/v1/shipmentConfirmations$'),
     rate: 10,
     burst: 10

--- a/clients/vendor-transaction-status-api-v1/src/client.ts
+++ b/clients/vendor-transaction-status-api-v1/src/client.ts
@@ -1,12 +1,13 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, VendorTransactionApi} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 import {VendorTransactionStatusApiError} from './error'
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
   {
+    method: 'get',
     urlRegex: new RegExp('^/vendor/transactions/v1/transactions/[^/]*$'),
     rate: 10,
     burst: 10

--- a/packages/common/__test__/axios/create-instance.spec.ts
+++ b/packages/common/__test__/axios/create-instance.spec.ts
@@ -26,7 +26,7 @@ describe('src/axios/create-instance', () => {
       const instance = createAxiosInstance({
         auth,
         region: 'eu',
-        rateLimits: [{urlRegex: /^\/test$/, rate: 1, burst: 1}],
+        rateLimits: [{method: 'get', urlRegex: /^\/test$/, rate: 1, burst: 1}],
         onRetry
       })
 
@@ -52,7 +52,7 @@ describe('src/axios/create-instance', () => {
       const instance = createAxiosInstance({
         auth,
         region: 'eu',
-        rateLimits: [{urlRegex: /^\/test$/, rate: 0.5, burst: 1}],
+        rateLimits: [{method: 'GET', urlRegex: /^\/test$/, rate: 0.5, burst: 1}],
         onRetry
       })
 
@@ -77,7 +77,7 @@ describe('src/axios/create-instance', () => {
       const instance = createAxiosInstance({
         auth,
         region: 'eu',
-        rateLimits: [{urlRegex: /^\/test$/, rate: 0.5, burst: 1}],
+        rateLimits: [{method: 'get', urlRegex: /^\/test$/, rate: 0.5, burst: 1}],
         onRetry
       })
 

--- a/packages/common/src/axios/create-instance.ts
+++ b/packages/common/src/axios/create-instance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, {Method} from 'axios'
 import {aws4Interceptor} from 'aws4-axios'
 import axiosRetry from 'axios-retry'
 
@@ -10,6 +10,7 @@ export interface RateLimit {
   urlRegex: RegExp;
   rate: number;
   burst: number;
+  method: Method;
 }
 
 export interface OnRetryParameters {
@@ -47,7 +48,7 @@ export function createAxiosInstance({
       retryDelay: (retryCount, error) => {
         const amznRateLimit: string = error.response?.headers['x-amzn-ratelimit-limit']
         const url = new URL(error.config.url!)
-        const rateLimit = amznRateLimit ? Number.parseFloat(amznRateLimit) : rateLimits.find(rateLimit => rateLimit.urlRegex.exec(url.pathname))?.rate
+        const rateLimit = amznRateLimit ? Number.parseFloat(amznRateLimit) : rateLimits.find(rateLimit => rateLimit.method.toLowerCase() === error.config.method?.toLowerCase() && rateLimit.urlRegex.exec(url.pathname))?.rate
         const delay = rateLimit && !Number.isNaN(rateLimit) ? (1 / rateLimit * 1000) + 1500 : (60 * 1000)
 
         if (onRetry) {

--- a/scripts/generate-clients.ts
+++ b/scripts/generate-clients.ts
@@ -62,6 +62,7 @@ async function generateClientVersion(clientName: string, filename: string) {
 
         if (result?.groups) {
           const value = {
+            method,
             rate: Number.parseFloat(result.groups.rate),
             burst: Number.parseFloat(result.groups.burst),
             urlRegex: `new RegExp('^${key.replace(/{.+}/g, '[^/]*')}$')`

--- a/scripts/templates/src/client.ts.mustache
+++ b/scripts/templates/src/client.ts.mustache
@@ -1,15 +1,16 @@
 /* eslint-disable prefer-regex-literals */
 import {Configuration, {{className}}} from './api-model'
 
-import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry} from '@sp-api-sdk/common'
+import {endpoints, awsRegionByCode, createAxiosInstance, ClientConfiguration, onRetry, RateLimit} from '@sp-api-sdk/common'
 
 {{=<% %>=}}
 import {<%errorClassName%>} from './error'
 <%={{ }}=%>
 
-export const RATE_LIMITS = [
+export const RATE_LIMITS: RateLimit[] = [
 {{#rateLimits}}
   {
+    method: '{{method}}',
     urlRegex: {{&urlRegex}},
     rate: {{rate}},
     burst: {{burst}}


### PR DESCRIPTION
Get the HTTP method for each route, in order to determine the good rate limiting if a route can be called by several HTTP methods