### PR TITLE
fix(auth): update the default value of session name for AWS role

### DIFF
--- a/packages/auth/src/selling-partner-api-auth.ts
+++ b/packages/auth/src/selling-partner-api-auth.ts
@@ -40,7 +40,7 @@ export class SellingPartnerApiAuth {
     const secretAccessKey = parameters.secretAccessKey || process.env.AWS_SECRET_ACCESS_KEY
     const region = parameters.region || process.env.AWS_DEFAULT_REGION
     const arn = parameters.role?.arn || process.env.AWS_ROLE_ARN
-    const sessionName = parameters.role?.sessionName || process.env.AWS_ROLE_SESSION_NAME || `${pkg.name}@${pkg.version}`
+    const sessionName = parameters.role?.sessionName || process.env.AWS_ROLE_SESSION_NAME || `${pkg.name.replace('/', '-')}@${pkg.version}`
     let role = null
 
     if (arn) {


### PR DESCRIPTION
Session name must satisfy regular expression pattern: [\w+=,.@-]*