### PR TITLE
ci: stop verifying npm access before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
         run: |
-          yarn lerna publish --yes --create-release github
+          yarn lerna publish --create-release github --no-verify-access --yes

--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,7 @@
     "publish": {
       "noPrivate": true,
       "conventionalCommits": true,
-      "message": "chore(release): publish"
+      "message": "chore(release): publish [skip ci]"
     }
   }
 }


### PR DESCRIPTION
Automation tokens do not work with lerna.
Skip CI when publishing.