### PR TITLE
chore(clients): stop linting clients as they’re generated

### DIFF
--- a/clients/aplus-content-api-2020-11-01/package.json
+++ b/clients/aplus-content-api-2020-11-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/authorization-api-v1/package.json
+++ b/clients/authorization-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/catalog-items-api-2020-12-01/package.json
+++ b/clients/catalog-items-api-2020-12-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/catalog-items-api-v0/package.json
+++ b/clients/catalog-items-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/fba-inbound-eligibility-api-v1/package.json
+++ b/clients/fba-inbound-eligibility-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/fba-inventory-api-v1/package.json
+++ b/clients/fba-inventory-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/fba-small-and-light-api-v1/package.json
+++ b/clients/fba-small-and-light-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/feeds-api-2020-09-04/package.json
+++ b/clients/feeds-api-2020-09-04/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/feeds-api-2021-06-30/package.json
+++ b/clients/feeds-api-2021-06-30/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/finances-api-v0/package.json
+++ b/clients/finances-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/fulfillment-inbound-api-v0/package.json
+++ b/clients/fulfillment-inbound-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/fulfillment-outbound-api-2020-07-01/package.json
+++ b/clients/fulfillment-outbound-api-2020-07-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/listings-items-api-2020-09-01/package.json
+++ b/clients/listings-items-api-2020-09-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/merchant-fulfillment-api-v0/package.json
+++ b/clients/merchant-fulfillment-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/messaging-api-v1/package.json
+++ b/clients/messaging-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/notifications-api-v1/package.json
+++ b/clients/notifications-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/orders-api-v0/package.json
+++ b/clients/orders-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/product-fees-api-v0/package.json
+++ b/clients/product-fees-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/product-pricing-api-v0/package.json
+++ b/clients/product-pricing-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/product-type-definitions-api-2020-09-01/package.json
+++ b/clients/product-type-definitions-api-2020-09-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/reports-api-2020-09-04/package.json
+++ b/clients/reports-api-2020-09-04/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/reports-api-2021-06-30/package.json
+++ b/clients/reports-api-2021-06-30/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/sales-api-v1/package.json
+++ b/clients/sales-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/sellers-api-v1/package.json
+++ b/clients/sellers-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/services-api-v1/package.json
+++ b/clients/services-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/shipment-invoicing-api-v0/package.json
+++ b/clients/shipment-invoicing-api-v0/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/shipping-api-v1/package.json
+++ b/clients/shipping-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/solicitations-api-v1/package.json
+++ b/clients/solicitations-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/tokens-api-2021-03-01/package.json
+++ b/clients/tokens-api-2021-03-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/uploads-api-2020-11-01/package.json
+++ b/clients/uploads-api-2020-11-01/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-direct-fulfillment-orders-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-direct-fulfillment-payments-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-invoices-api-v1/package.json
+++ b/clients/vendor-invoices-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-orders-api-v1/package.json
+++ b/clients/vendor-orders-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-shipments-api-v1/package.json
+++ b/clients/vendor-shipments-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/clients/vendor-transaction-status-api-v1/package.json
+++ b/clients/vendor-transaction-status-api-v1/package.json
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {

--- a/scripts/templates/package.json.mustache
+++ b/scripts/templates/package.json.mustache
@@ -22,7 +22,6 @@
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
     "clean": "rimraf dist",
-    "lint": "xo --cwd=../../ $PWD",
     "test": "NODE_ENV='test' yarn jest"
   },
   "dependencies": {


### PR DESCRIPTION
This will speed up the `test.yml` workflow.

We don’t actually need to lint generated code. :)