### PR TITLE
build(codegen): make code generation package a workspace package

### DIFF
--- a/clients/aplus-content-api-2020-11-01/package.json
+++ b/clients/aplus-content-api-2020-11-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/authorization-api-v1/package.json
+++ b/clients/authorization-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/catalog-items-api-2020-12-01/package.json
+++ b/clients/catalog-items-api-2020-12-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/catalog-items-api-v0/package.json
+++ b/clients/catalog-items-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/fba-inbound-eligibility-api-v1/package.json
+++ b/clients/fba-inbound-eligibility-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/fba-inventory-api-v1/package.json
+++ b/clients/fba-inventory-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/fba-small-and-light-api-v1/package.json
+++ b/clients/fba-small-and-light-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/feeds-api-2020-09-04/package.json
+++ b/clients/feeds-api-2020-09-04/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/feeds-api-2021-06-30/package.json
+++ b/clients/feeds-api-2021-06-30/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/finances-api-v0/package.json
+++ b/clients/finances-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/fulfillment-inbound-api-v0/package.json
+++ b/clients/fulfillment-inbound-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/fulfillment-outbound-api-2020-07-01/package.json
+++ b/clients/fulfillment-outbound-api-2020-07-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/listings-items-api-2020-09-01/package.json
+++ b/clients/listings-items-api-2020-09-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/listings-items-api-2021-08-01/package.json
+++ b/clients/listings-items-api-2021-08-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/listings-restrictions-api-2021-08-01/package.json
+++ b/clients/listings-restrictions-api-2021-08-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/merchant-fulfillment-api-v0/package.json
+++ b/clients/merchant-fulfillment-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/messaging-api-v1/package.json
+++ b/clients/messaging-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/notifications-api-v1/package.json
+++ b/clients/notifications-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/orders-api-v0/package.json
+++ b/clients/orders-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/product-fees-api-v0/package.json
+++ b/clients/product-fees-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/product-pricing-api-v0/package.json
+++ b/clients/product-pricing-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/product-type-definitions-api-2020-09-01/package.json
+++ b/clients/product-type-definitions-api-2020-09-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/reports-api-2020-09-04/package.json
+++ b/clients/reports-api-2020-09-04/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/reports-api-2021-06-30/package.json
+++ b/clients/reports-api-2021-06-30/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/sales-api-v1/package.json
+++ b/clients/sales-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/sellers-api-v1/package.json
+++ b/clients/sellers-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/services-api-v1/package.json
+++ b/clients/services-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/shipment-invoicing-api-v0/package.json
+++ b/clients/shipment-invoicing-api-v0/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/shipping-api-v1/package.json
+++ b/clients/shipping-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/solicitations-api-v1/package.json
+++ b/clients/solicitations-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/tokens-api-2021-03-01/package.json
+++ b/clients/tokens-api-2021-03-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/uploads-api-2020-11-01/package.json
+++ b/clients/uploads-api-2020-11-01/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-direct-fulfillment-orders-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-direct-fulfillment-payments-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-invoices-api-v1/package.json
+++ b/clients/vendor-invoices-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-orders-api-v1/package.json
+++ b/clients/vendor-orders-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-shipments-api-v1/package.json
+++ b/clients/vendor-shipments-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/clients/vendor-transaction-status-api-v1/package.json
+++ b/clients/vendor-transaction-status-api-v1/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/package.json
+++ b/package.json
@@ -38,20 +38,6 @@
     "typescript": "^4.5.5",
     "xo": "^0.47.0"
   },
-  "turbo": {
-    "pipeline": {
-      "clean": {
-        "cache": false,
-        "outputs": []
-      },
-      "check:ts": {},
-      "build": {
-        "dependsOn": [
-          "^build"
-        ]
-      }
-    }
-  },
   "xo": {
     "parserOptions": {
       "project": "./tsconfig.xo.json"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "workspaces": {
     "packages": [
+      "scripts",
       "packages/*",
       "clients/*"
     ]
@@ -14,7 +15,7 @@
   "scripts": {
     "build": "turbo run build",
     "clean": "turbo run clean",
-    "check:ts": "tsc --noEmit",
+    "check:ts": "turbo run check:ts",
     "test": "jest",
     "generate-clients": "ts-node --project scripts/tsconfig.json scripts/generate-clients.ts",
     "postgenerate-clients": "xo --fix"
@@ -22,38 +23,19 @@
   "dependencies": {},
   "devDependencies": {
     "@jest/types": "^27.5.1",
-    "@openapitools/openapi-generator-cli": "^2.4.26",
     "@tsconfig/node14": "^1.0.0",
-    "@types/bluebird": "^3.5.36",
     "@types/jest": "^27.4.0",
-    "@types/jsonfile": "^6.0.1",
-    "@types/lodash": "^4.14.178",
-    "@types/mustache": "^4.1.2",
-    "@types/rimraf": "^3.0.2",
-    "bluebird": "^3.7.2",
-    "camelcase": "^6.3.0",
-    "chalk": "^4.1.2",
     "conventional-changelog-conventionalcommits": "^4.6.3",
-    "fast-json-patch": "^3.1.0",
     "jest": "^27.5.0",
     "jest-junit": "^13.0.0",
-    "jsonfile": "^6.1.0",
     "lerna": "^4.0.0",
-    "lodash": "^4.17.21",
-    "mustache": "^4.2.0",
-    "openapi-types": "^10.0.0",
-    "remark": "^13.0.0",
-    "rimraf": "^3.0.2",
-    "strip-markdown": "^4.2.0",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.5.0",
     "turbo": "^1.1.2",
-    "type-fest": "^2.11.1",
     "typedoc": "^0.19.2",
     "typedoc-plugin-lerna-packages": "^0.3.1",
     "typedoc-plugin-remove-references": "^0.0.5",
     "typescript": "^4.5.5",
-    "winston": "^3.6.0",
     "xo": "^0.47.0"
   },
   "turbo": {
@@ -62,6 +44,7 @@
         "cache": false,
         "outputs": []
       },
+      "check:ts": {},
       "build": {
         "dependsOn": [
           "^build"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",
@@ -28,6 +29,9 @@
     "@aws-sdk/client-sts": "^3.51.0",
     "got": "^11.8.3",
     "read-pkg-up": "^7.0.1"
+  },
+  "devDependencies": {
+    "type-fest": "^2.11.2"
   },
   "repository": {
     "type": "git",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,6 +19,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/scripts/generate-clients.ts
+++ b/scripts/generate-clients.ts
@@ -44,6 +44,11 @@ async function readPackageVersion(path: string) {
   }
 }
 
+async function getAxiosVersion() {
+  const pkg = (await import('../packages/common/package.json')) as PackageJson
+  return pkg.dependencies!.axios
+}
+
 const cleaner = remark().use(remarkStrip)
 
 async function cleanMarkdown(input: string, stripNewLines?: boolean) {
@@ -109,7 +114,7 @@ async function generateClientVersion(clientName: string, filename: string) {
       dependencies: {
         auth: await readPackageVersion('packages/auth'),
         common: await readPackageVersion('packages/common'),
-        // TODO: retrieve other dependencies from existing clients, so we’re never out of date.
+        axios: await getAxiosVersion(),
       },
     }),
   )

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@sp-api-sdk/generator",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "check:ts": "yarn tsc --noEmit"
+  },
+  "dependencies": {
+    "@openapitools/openapi-generator-cli": "^2.4.26",
+    "bluebird": "^3.7.2",
+    "camelcase": "^6.3.0",
+    "chalk": "^4.1.2",
+    "fast-json-patch": "^3.1.0",
+    "jsonfile": "^6.1.0",
+    "lodash": "^4.17.21",
+    "mustache": "^4.2.0",
+    "openapi-types": "^10.0.0",
+    "remark": "^13.0.0",
+    "rimraf": "^3.0.2",
+    "strip-markdown": "^4.2.0",
+    "type-fest": "^2.11.2",
+    "winston": "^3.6.0"
+  },
+  "devDependencies": {
+    "@types/bluebird": "^3.5.36",
+    "@types/jsonfile": "^6.1.0",
+    "@types/lodash": "^4.14.178",
+    "@types/mustache": "^4.1.2",
+    "@types/rimraf": "^3.0.2"
+  }
+}

--- a/scripts/templates/package.json.mustache
+++ b/scripts/templates/package.json.mustache
@@ -27,7 +27,7 @@
   "dependencies": {
     "@sp-api-sdk/auth": "^{{dependencies.auth}}",
     "@sp-api-sdk/common": "^{{dependencies.common}}",
-    "axios": "^0.25.0"
+    "axios": "{{dependencies.axios}}"
   },
   "repository": {
     "type": "git",

--- a/scripts/templates/package.json.mustache
+++ b/scripts/templates/package.json.mustache
@@ -18,6 +18,7 @@
     "dist/**/*.d.ts"
   ],
   "scripts": {
+    "check:ts": "yarn tsc --noEmit",
     "build:cjs": "tsc -p tsconfig.json",
     "build:es": "tsc -p tsconfig.es.json",
     "build": "yarn build:cjs && yarn build:es",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "include": [
     "**/*.ts"
   ]

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "pipeline": {
+    "clean": {
+      "cache": false,
+      "outputs": []
+    },
+    "check:ts": {},
+    "build": {
+      "dependsOn": [
+        "^build"
+      ]
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,10 +2406,10 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/jsonfile@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.0.1.tgz#639eff0748d60dfbc9d5f743ca7178bd93f53c71"
-  integrity sha512-SSCc8i9yl6vjgXSyZb0uEodk3UjXuWd55t1D+Ie1zuTx7ml+2AEj0Xyomi3NBz1gCBsZVyWWnXOLXowS1ufhEw==
+"@types/jsonfile@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.0.tgz#c413d113ae28619f418b8a6ce7a1dec29e8f8a1c"
+  integrity sha512-zQPywzif9EycCkvECjYT9dbbttT0dkk657zcLb/803ZOXHsBA963jzEPF/Jnh1zOdBbgFJvUE8kcvZverAoK1w==
   dependencies:
     "@types/node" "*"
 
@@ -9175,10 +9175,15 @@ type-fest@^1.0.1, type-fest@^1.2.1, type-fest@^1.2.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
-type-fest@^2.0.0, type-fest@^2.11.1:
+type-fest@^2.0.0:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.11.1.tgz#04ddf5c0dbbd403fb8270d98ad1b4857e7ff7b24"
   integrity sha512-fPcV5KLAqFfmhHobtAUwEpbpfYhVF7wSLVgbG/7mIGe/Pete7ky/bPAPRkzbWdrj0/EkswFAAR2feJCgigkUKg==
+
+type-fest@^2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.11.2.tgz#5534a919858bc517492cd3a53a673835a76d2e71"
+  integrity sha512-reW2Y2Mpn0QNA/5fvtm5doROLwDPu2zOm5RtY7xQQS05Q7xgC8MOZ3yPNaP9m/s/sNjjFQtHo7VCNqYW2iI+Ig==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"


### PR DESCRIPTION
- Make `scripts` a standalone workspace package.
- Move all global dependencies to their own packages where needed.
- Run `check:ts` in individual packages, so they use their own tsconfig.
- Retrieve axios version from `common` package.
