### PR TITLE
build(codegen): improve clients generation

### DIFF
--- a/codegen/templates/README.md.mustache
+++ b/codegen/templates/README.md.mustache
@@ -7,7 +7,7 @@
 
 ## Documentation
 
-Learn more about this Selling Partner API by visiting the [official documentation]({{&docUrl}}).
+Learn more about this Selling Partner API by visiting the [official documentation](https://developer-docs.amazon.com/sp-api/docs).
 
 Also, see the [generated documentation]({{&sdkClientDocUrl}}) for this API client.
 
@@ -94,7 +94,7 @@ const client = new {{className}}({
 })
 ```
 
-The rate limits used for each route are specified in the [API documentation]({{&docUrl}}).
+The rate limits used for each route are specified in the [API documentation](https://developer-docs.amazon.com/sp-api/docs).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "check:ts": "turbo run check:ts",
     "test": "jest",
     "generate-clients": "ts-node --project codegen/tsconfig.json codegen/generate-clients.ts",
-    "postgenerate-clients": "xo --fix"
+    "postgenerate-clients": "xo --fix clients"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Replace doc: markdown URLs with the official doc site.
Remove links to outdated GitHub doc.

Close #298 