### PR TITLE
feat: expose request types and base API classes

### DIFF
--- a/clients/amazon-warehousing-and-distribution-2024-05-09/index.ts
+++ b/clients/amazon-warehousing-and-distribution-2024-05-09/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/aplus-content-api-2020-11-01/index.ts
+++ b/clients/aplus-content-api-2020-11-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/application-management-api-2023-11-30/index.ts
+++ b/clients/application-management-api-2023-11-30/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/catalog-items-api-2020-12-01/index.ts
+++ b/clients/catalog-items-api-2020-12-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/catalog-items-api-2022-04-01/index.ts
+++ b/clients/catalog-items-api-2022-04-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/catalog-items-api-v0/index.ts
+++ b/clients/catalog-items-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/data-kiosk-api-2023-11-15/index.ts
+++ b/clients/data-kiosk-api-2023-11-15/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/easy-ship-2022-03-23/index.ts
+++ b/clients/easy-ship-2022-03-23/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/fba-inbound-eligibility-api-v1/index.ts
+++ b/clients/fba-inbound-eligibility-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/fba-inventory-api-v1/index.ts
+++ b/clients/fba-inventory-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/feeds-api-2020-09-04/index.ts
+++ b/clients/feeds-api-2020-09-04/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/feeds-api-2021-06-30/index.ts
+++ b/clients/feeds-api-2021-06-30/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/finances-api-v0/index.ts
+++ b/clients/finances-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/fulfillment-inbound-api-2024-03-20/index.ts
+++ b/clients/fulfillment-inbound-api-2024-03-20/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/fulfillment-inbound-api-v0/index.ts
+++ b/clients/fulfillment-inbound-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/fulfillment-outbound-api-2020-07-01/index.ts
+++ b/clients/fulfillment-outbound-api-2020-07-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/listings-items-api-2020-09-01/index.ts
+++ b/clients/listings-items-api-2020-09-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/listings-items-api-2021-08-01/index.ts
+++ b/clients/listings-items-api-2021-08-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/listings-restrictions-api-2021-08-01/index.ts
+++ b/clients/listings-restrictions-api-2021-08-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/merchant-fulfillment-api-v0/index.ts
+++ b/clients/merchant-fulfillment-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/messaging-api-v1/index.ts
+++ b/clients/messaging-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/notifications-api-v1/index.ts
+++ b/clients/notifications-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/orders-api-v0/index.ts
+++ b/clients/orders-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/product-fees-api-v0/index.ts
+++ b/clients/product-fees-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/product-pricing-api-2022-05-01/index.ts
+++ b/clients/product-pricing-api-2022-05-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/product-pricing-api-v0/index.ts
+++ b/clients/product-pricing-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/product-type-definitions-api-2020-09-01/index.ts
+++ b/clients/product-type-definitions-api-2020-09-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/replenishment-api-2022-11-07/index.ts
+++ b/clients/replenishment-api-2022-11-07/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/reports-api-2020-09-04/index.ts
+++ b/clients/reports-api-2020-09-04/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/reports-api-2021-06-30/index.ts
+++ b/clients/reports-api-2021-06-30/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/sales-api-v1/index.ts
+++ b/clients/sales-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/sellers-api-v1/index.ts
+++ b/clients/sellers-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/services-api-v1/index.ts
+++ b/clients/services-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/shipment-invoicing-api-v0/index.ts
+++ b/clients/shipment-invoicing-api-v0/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/shipping-api-v1/index.ts
+++ b/clients/shipping-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/shipping-api-v2/index.ts
+++ b/clients/shipping-api-v2/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/solicitations-api-v1/index.ts
+++ b/clients/solicitations-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/supply-sources-api-2020-07-01/index.ts
+++ b/clients/supply-sources-api-2020-07-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/tokens-api-2021-03-01/index.ts
+++ b/clients/tokens-api-2021-03-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/uploads-api-2020-11-01/index.ts
+++ b/clients/uploads-api-2020-11-01/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/index.ts
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/index.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-orders-api-v1/index.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-payments-api-v1/index.ts
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/index.ts
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/index.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/index.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/index.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/index.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-invoices-api-v1/index.ts
+++ b/clients/vendor-invoices-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-orders-api-v1/index.ts
+++ b/clients/vendor-orders-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-shipments-api-v1/index.ts
+++ b/clients/vendor-shipments-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/clients/vendor-transaction-status-api-v1/index.ts
+++ b/clients/vendor-transaction-status-api-v1/index.ts
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/codegen/templates/index.ts.mustache
+++ b/codegen/templates/index.ts.mustache
@@ -1,2 +1,3 @@
 export * from './src/client'
+export * from './src/api-model/api'
 export * from './src/api-model/models'

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "codegen/node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.7.0"
+    "version": "7.8.0"
   }
 }


### PR DESCRIPTION
- `SellersApiClient` uses a custom configured axios instance.
- Use `SellersApi` if you want to use your own axios instance.

Close #757