### PR TITLE
chore: bump openapi generator to v7.22.0

### DIFF
--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/src/api-model/api/amazon-warehousing-and-distribution-api.ts
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/src/api-model/api/amazon-warehousing-and-distribution-api.ts
@@ -66,7 +66,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('cancelInbound', 'orderId', orderId)
             const localVarPath = `/awd/2024-05-09/inboundOrders/{orderId}/cancellation`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -133,7 +133,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('confirmInbound', 'orderId', orderId)
             const localVarPath = `/awd/2024-05-09/inboundOrders/{orderId}/confirmation`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -166,7 +166,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('confirmReplenishmentOrder', 'orderId', orderId)
             const localVarPath = `/awd/2024-05-09/replenishmentOrders/{orderId}/confirmation`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -267,7 +267,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getInbound', 'orderId', orderId)
             const localVarPath = `/awd/2024-05-09/inboundOrders/{orderId}`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -301,7 +301,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getInboundShipment', 'shipmentId', shipmentId)
             const localVarPath = `/awd/2024-05-09/inboundShipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -340,7 +340,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getInboundShipmentLabels', 'shipmentId', shipmentId)
             const localVarPath = `/awd/2024-05-09/inboundShipments/{shipmentId}/labels`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -381,7 +381,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getReplenishmentOrder', 'orderId', orderId)
             const localVarPath = `/awd/2024-05-09/replenishmentOrders/{orderId}`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -597,7 +597,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateInbound', 'body', body)
             const localVarPath = `/awd/2024-05-09/inboundOrders/{orderId}`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -635,7 +635,7 @@ export const AmazonWarehousingAndDistributionApiAxiosParamCreator = function (co
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateInboundShipmentTransportDetails', 'body', body)
             const localVarPath = `/awd/2024-05-09/inboundShipments/{shipmentId}/transport`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/src/api-model/configuration.ts
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/aplus-content-api-2020-11-01/src/api-model/api/aplus-content-api.ts
+++ b/clients/aplus-content-api-2020-11-01/src/api-model/api/aplus-content-api.ts
@@ -107,7 +107,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'includedDataSet' is not null or undefined
             assertParamExists('getContentDocument', 'includedDataSet', includedDataSet)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -154,7 +154,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('listContentDocumentAsinRelations', 'marketplaceId', marketplaceId)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}/asins`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -206,7 +206,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('postContentDocumentApprovalSubmission', 'marketplaceId', marketplaceId)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}/approvalSubmissions`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -249,7 +249,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'postContentDocumentAsinRelationsRequest' is not null or undefined
             assertParamExists('postContentDocumentAsinRelations', 'postContentDocumentAsinRelationsRequest', postContentDocumentAsinRelationsRequest)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}/asins`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -291,7 +291,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('postContentDocumentSuspendSubmission', 'marketplaceId', marketplaceId)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}/suspendSubmissions`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -423,7 +423,7 @@ export const AplusContentApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'postContentDocumentRequest' is not null or undefined
             assertParamExists('updateContentDocument', 'postContentDocumentRequest', postContentDocumentRequest)
             const localVarPath = `/aplus/2020-11-01/contentDocuments/{contentReferenceKey}`
-                .replace(`{${"contentReferenceKey"}}`, encodeURIComponent(String(contentReferenceKey)));
+                .replace('{contentReferenceKey}', encodeURIComponent(String(contentReferenceKey)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/aplus-content-api-2020-11-01/src/api-model/configuration.ts
+++ b/clients/aplus-content-api-2020-11-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/application-integrations-api-2024-04-01/src/api-model/api/application-integrations-api.ts
+++ b/clients/application-integrations-api-2024-04-01/src/api-model/api/application-integrations-api.ts
@@ -117,7 +117,7 @@ export const ApplicationIntegrationsApiAxiosParamCreator = function (configurati
             // verify required parameter 'body' is not null or undefined
             assertParamExists('recordActionFeedback', 'body', body)
             const localVarPath = `/appIntegrations/2024-04-01/notifications/{notificationId}/feedback`
-                .replace(`{${"notificationId"}}`, encodeURIComponent(String(notificationId)));
+                .replace('{notificationId}', encodeURIComponent(String(notificationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/application-integrations-api-2024-04-01/src/api-model/configuration.ts
+++ b/clients/application-integrations-api-2024-04-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/application-management-api-2023-11-30/src/api-model/configuration.ts
+++ b/clients/application-management-api-2023-11-30/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/catalog-items-api-2020-12-01/src/api-model/api/catalog-items-api.ts
+++ b/clients/catalog-items-api-2020-12-01/src/api-model/api/catalog-items-api.ts
@@ -47,7 +47,7 @@ export const CatalogItemsApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getCatalogItem', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/catalog/2020-12-01/items/{asin}`
-                .replace(`{${"asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/catalog-items-api-2020-12-01/src/api-model/configuration.ts
+++ b/clients/catalog-items-api-2020-12-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/catalog-items-api-2022-04-01/src/api-model/api/catalog-items-api.ts
+++ b/clients/catalog-items-api-2022-04-01/src/api-model/api/catalog-items-api.ts
@@ -47,7 +47,7 @@ export const CatalogItemsApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getCatalogItem', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/catalog/2022-04-01/items/{asin}`
-                .replace(`{${"asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/catalog-items-api-2022-04-01/src/api-model/configuration.ts
+++ b/clients/catalog-items-api-2022-04-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/catalog-items-api-v0/src/api-model/configuration.ts
+++ b/clients/catalog-items-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/customer-feedback-api-2024-06-01/src/api-model/api/customer-feedback-api.ts
+++ b/clients/customer-feedback-api-2024-06-01/src/api-model/api/customer-feedback-api.ts
@@ -55,7 +55,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getBrowseNodeReturnTopics', 'marketplaceId', marketplaceId)
             const localVarPath = `/customerFeedback/2024-06-01/browseNodes/{browseNodeId}/returns/topics`
-                .replace(`{${"browseNodeId"}}`, encodeURIComponent(String(browseNodeId)));
+                .replace('{browseNodeId}', encodeURIComponent(String(browseNodeId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -95,7 +95,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getBrowseNodeReturnTrends', 'marketplaceId', marketplaceId)
             const localVarPath = `/customerFeedback/2024-06-01/browseNodes/{browseNodeId}/returns/trends`
-                .replace(`{${"browseNodeId"}}`, encodeURIComponent(String(browseNodeId)));
+                .replace('{browseNodeId}', encodeURIComponent(String(browseNodeId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -138,7 +138,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'sortBy' is not null or undefined
             assertParamExists('getBrowseNodeReviewTopics', 'sortBy', sortBy)
             const localVarPath = `/customerFeedback/2024-06-01/browseNodes/{browseNodeId}/reviews/topics`
-                .replace(`{${"browseNodeId"}}`, encodeURIComponent(String(browseNodeId)));
+                .replace('{browseNodeId}', encodeURIComponent(String(browseNodeId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -182,7 +182,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getBrowseNodeReviewTrends', 'marketplaceId', marketplaceId)
             const localVarPath = `/customerFeedback/2024-06-01/browseNodes/{browseNodeId}/reviews/trends`
-                .replace(`{${"browseNodeId"}}`, encodeURIComponent(String(browseNodeId)));
+                .replace('{browseNodeId}', encodeURIComponent(String(browseNodeId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -222,7 +222,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getItemBrowseNode', 'marketplaceId', marketplaceId)
             const localVarPath = `/customerFeedback/2024-06-01/items/{asin}/browseNode`
-                .replace(`{${"asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -265,7 +265,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'sortBy' is not null or undefined
             assertParamExists('getItemReviewTopics', 'sortBy', sortBy)
             const localVarPath = `/customerFeedback/2024-06-01/items/{asin}/reviews/topics`
-                .replace(`{${"asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -309,7 +309,7 @@ export const CustomerFeedbackApiAxiosParamCreator = function (configuration?: Co
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getItemReviewTrends', 'marketplaceId', marketplaceId)
             const localVarPath = `/customerFeedback/2024-06-01/items/{asin}/reviews/trends`
-                .replace(`{${"asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/customer-feedback-api-2024-06-01/src/api-model/configuration.ts
+++ b/clients/customer-feedback-api-2024-06-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/data-kiosk-api-2023-11-15/src/api-model/api/data-kiosk-api.ts
+++ b/clients/data-kiosk-api-2023-11-15/src/api-model/api/data-kiosk-api.ts
@@ -48,7 +48,7 @@ export const DataKioskApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'queryId' is not null or undefined
             assertParamExists('cancelQuery', 'queryId', queryId)
             const localVarPath = `/dataKiosk/2023-11-15/queries/{queryId}`
-                .replace(`{${"queryId"}}`, encodeURIComponent(String(queryId)));
+                .replace('{queryId}', encodeURIComponent(String(queryId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -115,7 +115,7 @@ export const DataKioskApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'documentId' is not null or undefined
             assertParamExists('getDocument', 'documentId', documentId)
             const localVarPath = `/dataKiosk/2023-11-15/documents/{documentId}`
-                .replace(`{${"documentId"}}`, encodeURIComponent(String(documentId)));
+                .replace('{documentId}', encodeURIComponent(String(documentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -206,7 +206,7 @@ export const DataKioskApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'queryId' is not null or undefined
             assertParamExists('getQuery', 'queryId', queryId)
             const localVarPath = `/dataKiosk/2023-11-15/queries/{queryId}`
-                .replace(`{${"queryId"}}`, encodeURIComponent(String(queryId)));
+                .replace('{queryId}', encodeURIComponent(String(queryId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/data-kiosk-api-2023-11-15/src/api-model/configuration.ts
+++ b/clients/data-kiosk-api-2023-11-15/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/src/api-model/configuration.ts
+++ b/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/easy-ship-api-2022-03-23/src/api-model/configuration.ts
+++ b/clients/easy-ship-api-2022-03-23/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/external-fulfillment-inventory-api-2024-09-11/src/api-model/configuration.ts
+++ b/clients/external-fulfillment-inventory-api-2024-09-11/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/external-fulfillment-returns-api-2024-09-11/src/api-model/api/external-fulfillment-returns-api.ts
+++ b/clients/external-fulfillment-returns-api-2024-09-11/src/api-model/api/external-fulfillment-returns-api.ts
@@ -42,7 +42,7 @@ export const ExternalFulfillmentReturnsApiAxiosParamCreator = function (configur
             // verify required parameter 'returnId' is not null or undefined
             assertParamExists('getReturn', 'returnId', returnId)
             const localVarPath = `/externalFulfillment/2024-09-11/returns/{returnId}`
-                .replace(`{${"returnId"}}`, encodeURIComponent(String(returnId)));
+                .replace('{returnId}', encodeURIComponent(String(returnId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/external-fulfillment-returns-api-2024-09-11/src/api-model/configuration.ts
+++ b/clients/external-fulfillment-returns-api-2024-09-11/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/external-fulfillment-shipments-api-2024-09-11/src/api-model/api/external-fulfillment-shipments-api.ts
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/src/api-model/api/external-fulfillment-shipments-api.ts
@@ -61,7 +61,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createPackages', 'body', body)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/packages`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -96,7 +96,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('generateInvoice', 'shipmentId', shipmentId)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/invoice`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -134,7 +134,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'operation' is not null or undefined
             assertParamExists('generateShipLabels', 'operation', operation)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/shipLabels`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -177,7 +177,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipment', 'shipmentId', shipmentId)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -289,7 +289,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'operation' is not null or undefined
             assertParamExists('processShipment', 'operation', operation)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -328,7 +328,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('retrieveInvoice', 'shipmentId', shipmentId)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/invoice`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -364,7 +364,7 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'packageId' is not null or undefined
             assertParamExists('retrieveShippingOptions', 'packageId', packageId)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/shippingOptions`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -407,8 +407,8 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updatePackage', 'body', body)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/packages/{packageId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"packageId"}}`, encodeURIComponent(String(packageId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{packageId}', encodeURIComponent(String(packageId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -448,8 +448,8 @@ export const ExternalFulfillmentShipmentsApiAxiosParamCreator = function (config
             // verify required parameter 'packageId' is not null or undefined
             assertParamExists('updatePackageStatus', 'packageId', packageId)
             const localVarPath = `/externalFulfillment/2024-09-11/shipments/{shipmentId}/packages/{packageId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"packageId"}}`, encodeURIComponent(String(packageId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{packageId}', encodeURIComponent(String(packageId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/external-fulfillment-shipments-api-2024-09-11/src/api-model/configuration.ts
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/fba-inbound-eligibility-api-v1/src/api-model/configuration.ts
+++ b/clients/fba-inbound-eligibility-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/fba-inventory-api-v1/src/api-model/api/fba-inventory-api.ts
+++ b/clients/fba-inventory-api-v1/src/api-model/api/fba-inventory-api.ts
@@ -125,7 +125,7 @@ export const FbaInventoryApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('deleteInventoryItem', 'marketplaceId', marketplaceId)
             const localVarPath = `/fba/inventory/v1/items/{sellerSku}`
-                .replace(`{${"sellerSku"}}`, encodeURIComponent(String(sellerSku)));
+                .replace('{sellerSku}', encodeURIComponent(String(sellerSku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/fba-inventory-api-v1/src/api-model/configuration.ts
+++ b/clients/fba-inventory-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/feeds-api-2021-06-30/src/api-model/api/feeds-api.ts
+++ b/clients/feeds-api-2021-06-30/src/api-model/api/feeds-api.ts
@@ -52,7 +52,7 @@ export const FeedsApiAxiosParamCreator = function (configuration?: Configuration
             // verify required parameter 'feedId' is not null or undefined
             assertParamExists('cancelFeed', 'feedId', feedId)
             const localVarPath = `/feeds/2021-06-30/feeds/{feedId}`
-                .replace(`{${"feedId"}}`, encodeURIComponent(String(feedId)));
+                .replace('{feedId}', encodeURIComponent(String(feedId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -153,7 +153,7 @@ export const FeedsApiAxiosParamCreator = function (configuration?: Configuration
             // verify required parameter 'feedId' is not null or undefined
             assertParamExists('getFeed', 'feedId', feedId)
             const localVarPath = `/feeds/2021-06-30/feeds/{feedId}`
-                .replace(`{${"feedId"}}`, encodeURIComponent(String(feedId)));
+                .replace('{feedId}', encodeURIComponent(String(feedId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -187,7 +187,7 @@ export const FeedsApiAxiosParamCreator = function (configuration?: Configuration
             // verify required parameter 'feedDocumentId' is not null or undefined
             assertParamExists('getFeedDocument', 'feedDocumentId', feedDocumentId)
             const localVarPath = `/feeds/2021-06-30/documents/{feedDocumentId}`
-                .replace(`{${"feedDocumentId"}}`, encodeURIComponent(String(feedDocumentId)));
+                .replace('{feedDocumentId}', encodeURIComponent(String(feedDocumentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/feeds-api-2021-06-30/src/api-model/configuration.ts
+++ b/clients/feeds-api-2021-06-30/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/finances-api-2024-06-19/src/api-model/configuration.ts
+++ b/clients/finances-api-2024-06-19/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/finances-api-v0/src/api-model/api/finances-api.ts
+++ b/clients/finances-api-v0/src/api-model/api/finances-api.ts
@@ -150,7 +150,7 @@ export const FinancesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'eventGroupId' is not null or undefined
             assertParamExists('listFinancialEventsByGroupId', 'eventGroupId', eventGroupId)
             const localVarPath = `/finances/v0/financialEventGroups/{eventGroupId}/financialEvents`
-                .replace(`{${"eventGroupId"}}`, encodeURIComponent(String(eventGroupId)));
+                .replace('{eventGroupId}', encodeURIComponent(String(eventGroupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -205,7 +205,7 @@ export const FinancesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('listFinancialEventsByOrderId', 'orderId', orderId)
             const localVarPath = `/finances/v0/orders/{orderId}/financialEvents`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/finances-api-v0/src/api-model/configuration.ts
+++ b/clients/finances-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/finances-transfers-api-2024-06-01/src/api-model/configuration.ts
+++ b/clients/finances-transfers-api-2024-06-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/fulfillment-inbound-api-2024-03-20/src/api-model/api/fulfillment-inbound-api.ts
+++ b/clients/fulfillment-inbound-api-2024-03-20/src/api-model/api/fulfillment-inbound-api.ts
@@ -156,7 +156,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('cancelInboundPlan', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/cancellation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -195,8 +195,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('cancelSelfShipAppointment', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/selfShipAppointmentCancellation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -237,9 +237,9 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'deliveryWindowOptionId' is not null or undefined
             assertParamExists('confirmDeliveryWindowOptions', 'deliveryWindowOptionId', deliveryWindowOptionId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/deliveryWindowOptions/{deliveryWindowOptionId}/confirmation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"deliveryWindowOptionId"}}`, encodeURIComponent(String(deliveryWindowOptionId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{deliveryWindowOptionId}', encodeURIComponent(String(deliveryWindowOptionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -275,8 +275,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'packingOptionId' is not null or undefined
             assertParamExists('confirmPackingOption', 'packingOptionId', packingOptionId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingOptions/{packingOptionId}/confirmation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"packingOptionId"}}`, encodeURIComponent(String(packingOptionId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{packingOptionId}', encodeURIComponent(String(packingOptionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -312,8 +312,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'placementOptionId' is not null or undefined
             assertParamExists('confirmPlacementOption', 'placementOptionId', placementOptionId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/placementOptions/{placementOptionId}/confirmation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"placementOptionId"}}`, encodeURIComponent(String(placementOptionId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{placementOptionId}', encodeURIComponent(String(placementOptionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -352,9 +352,9 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'contentUpdatePreviewId' is not null or undefined
             assertParamExists('confirmShipmentContentUpdatePreview', 'contentUpdatePreviewId', contentUpdatePreviewId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/contentUpdatePreviews/{contentUpdatePreviewId}/confirmation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"contentUpdatePreviewId"}}`, encodeURIComponent(String(contentUpdatePreviewId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{contentUpdatePreviewId}', encodeURIComponent(String(contentUpdatePreviewId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -390,7 +390,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('confirmTransportationOptions', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/transportationOptions/confirmation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -496,8 +496,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('generateDeliveryWindowOptions', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/deliveryWindowOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -530,7 +530,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('generatePackingOptions', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -566,7 +566,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('generatePlacementOptions', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/placementOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -607,8 +607,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('generateSelfShipAppointmentSlots', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/selfShipAppointmentSlots`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -649,8 +649,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('generateShipmentContentUpdatePreviews', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/contentUpdatePreviews`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -688,7 +688,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('generateTransportationOptions', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/transportationOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -726,8 +726,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getDeliveryChallanDocument', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/deliveryChallanDocument`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -760,7 +760,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'operationId' is not null or undefined
             assertParamExists('getInboundOperationStatus', 'operationId', operationId)
             const localVarPath = `/inbound/fba/2024-03-20/operations/{operationId}`
-                .replace(`{${"operationId"}}`, encodeURIComponent(String(operationId)));
+                .replace('{operationId}', encodeURIComponent(String(operationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -793,7 +793,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('getInboundPlan', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -831,8 +831,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getSelfShipAppointmentSlots', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/selfShipAppointmentSlots`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -876,8 +876,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipment', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -916,9 +916,9 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'contentUpdatePreviewId' is not null or undefined
             assertParamExists('getShipmentContentUpdatePreview', 'contentUpdatePreviewId', contentUpdatePreviewId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/contentUpdatePreviews/{contentUpdatePreviewId}`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"contentUpdatePreviewId"}}`, encodeURIComponent(String(contentUpdatePreviewId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{contentUpdatePreviewId}', encodeURIComponent(String(contentUpdatePreviewId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -956,8 +956,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('listDeliveryWindowOptions', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/deliveryWindowOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1000,7 +1000,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listInboundPlanBoxes', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/boxes`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1043,7 +1043,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listInboundPlanItems', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/items`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1086,7 +1086,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listInboundPlanPallets', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/pallets`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1229,8 +1229,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'packingGroupId' is not null or undefined
             assertParamExists('listPackingGroupBoxes', 'packingGroupId', packingGroupId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingGroups/{packingGroupId}/boxes`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"packingGroupId"}}`, encodeURIComponent(String(packingGroupId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{packingGroupId}', encodeURIComponent(String(packingGroupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1276,8 +1276,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'packingGroupId' is not null or undefined
             assertParamExists('listPackingGroupItems', 'packingGroupId', packingGroupId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingGroups/{packingGroupId}/items`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"packingGroupId"}}`, encodeURIComponent(String(packingGroupId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{packingGroupId}', encodeURIComponent(String(packingGroupId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1320,7 +1320,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listPackingOptions', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1363,7 +1363,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listPlacementOptions', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/placementOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1452,8 +1452,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('listShipmentBoxes', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/boxes`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1499,8 +1499,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('listShipmentContentUpdatePreviews', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/contentUpdatePreviews`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1546,8 +1546,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('listShipmentItems', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/items`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1593,8 +1593,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('listShipmentPallets', 'shipmentId', shipmentId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/pallets`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1639,7 +1639,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'inboundPlanId' is not null or undefined
             assertParamExists('listTransportationOptions', 'inboundPlanId', inboundPlanId)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/transportationOptions`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1697,9 +1697,9 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('scheduleSelfShipAppointment', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/selfShipAppointmentSlots/{slotId}/schedule`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"slotId"}}`, encodeURIComponent(String(slotId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{slotId}', encodeURIComponent(String(slotId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1737,7 +1737,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('setPackingInformation', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/packingInformation`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1809,7 +1809,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateInboundPlanName', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/name`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1891,8 +1891,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateShipmentName', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/name`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1933,8 +1933,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateShipmentSourceAddress', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/sourceAddress`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -1975,8 +1975,8 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateShipmentTrackingDetails', 'body', body)
             const localVarPath = `/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/trackingDetails`
-                .replace(`{${"inboundPlanId"}}`, encodeURIComponent(String(inboundPlanId)))
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{inboundPlanId}', encodeURIComponent(String(inboundPlanId)))
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/fulfillment-inbound-api-2024-03-20/src/api-model/configuration.ts
+++ b/clients/fulfillment-inbound-api-2024-03-20/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/fulfillment-inbound-api-v0/src/api-model/api/fulfillment-inbound-api.ts
+++ b/clients/fulfillment-inbound-api-v0/src/api-model/api/fulfillment-inbound-api.ts
@@ -46,7 +46,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getBillOfLading', 'shipmentId', shipmentId)
             const localVarPath = `/fba/inbound/v0/shipments/{shipmentId}/billOfLading`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -90,7 +90,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'labelType' is not null or undefined
             assertParamExists('getLabels', 'labelType', labelType)
             const localVarPath = `/fba/inbound/v0/shipments/{shipmentId}/labels`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -260,7 +260,7 @@ export const FulfillmentInboundApiAxiosParamCreator = function (configuration?: 
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipmentItemsByShipmentId', 'shipmentId', shipmentId)
             const localVarPath = `/fba/inbound/v0/shipments/{shipmentId}/items`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/fulfillment-inbound-api-v0/src/api-model/configuration.ts
+++ b/clients/fulfillment-inbound-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/fulfillment-outbound-api-2020-07-01/src/api-model/api/fulfillment-outbound-api.ts
+++ b/clients/fulfillment-outbound-api-2020-07-01/src/api-model/api/fulfillment-outbound-api.ts
@@ -76,7 +76,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'sellerFulfillmentOrderId' is not null or undefined
             assertParamExists('cancelFulfillmentOrder', 'sellerFulfillmentOrderId', sellerFulfillmentOrderId)
             const localVarPath = `/fba/outbound/2020-07-01/fulfillmentOrders/{sellerFulfillmentOrderId}/cancel`
-                .replace(`{${"sellerFulfillmentOrderId"}}`, encodeURIComponent(String(sellerFulfillmentOrderId)));
+                .replace('{sellerFulfillmentOrderId}', encodeURIComponent(String(sellerFulfillmentOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -146,7 +146,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createFulfillmentReturn', 'body', body)
             const localVarPath = `/fba/outbound/2020-07-01/fulfillmentOrders/{sellerFulfillmentOrderId}/return`
-                .replace(`{${"sellerFulfillmentOrderId"}}`, encodeURIComponent(String(sellerFulfillmentOrderId)));
+                .replace('{sellerFulfillmentOrderId}', encodeURIComponent(String(sellerFulfillmentOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -220,7 +220,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'featureName' is not null or undefined
             assertParamExists('getFeatureInventory', 'featureName', featureName)
             const localVarPath = `/fba/outbound/2020-07-01/features/inventory/{featureName}`
-                .replace(`{${"featureName"}}`, encodeURIComponent(String(featureName)));
+                .replace('{featureName}', encodeURIComponent(String(featureName)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -273,8 +273,8 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'sellerSku' is not null or undefined
             assertParamExists('getFeatureSKU', 'sellerSku', sellerSku)
             const localVarPath = `/fba/outbound/2020-07-01/features/inventory/{featureName}/{sellerSku}`
-                .replace(`{${"featureName"}}`, encodeURIComponent(String(featureName)))
-                .replace(`{${"sellerSku"}}`, encodeURIComponent(String(sellerSku)));
+                .replace('{featureName}', encodeURIComponent(String(featureName)))
+                .replace('{sellerSku}', encodeURIComponent(String(sellerSku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -347,7 +347,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'sellerFulfillmentOrderId' is not null or undefined
             assertParamExists('getFulfillmentOrder', 'sellerFulfillmentOrderId', sellerFulfillmentOrderId)
             const localVarPath = `/fba/outbound/2020-07-01/fulfillmentOrders/{sellerFulfillmentOrderId}`
-                .replace(`{${"sellerFulfillmentOrderId"}}`, encodeURIComponent(String(sellerFulfillmentOrderId)));
+                .replace('{sellerFulfillmentOrderId}', encodeURIComponent(String(sellerFulfillmentOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -545,7 +545,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'body' is not null or undefined
             assertParamExists('submitFulfillmentOrderStatusUpdate', 'body', body)
             const localVarPath = `/fba/outbound/2020-07-01/fulfillmentOrders/{sellerFulfillmentOrderId}/status`
-                .replace(`{${"sellerFulfillmentOrderId"}}`, encodeURIComponent(String(sellerFulfillmentOrderId)));
+                .replace('{sellerFulfillmentOrderId}', encodeURIComponent(String(sellerFulfillmentOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -583,7 +583,7 @@ export const FulfillmentOutboundApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateFulfillmentOrder', 'body', body)
             const localVarPath = `/fba/outbound/2020-07-01/fulfillmentOrders/{sellerFulfillmentOrderId}`
-                .replace(`{${"sellerFulfillmentOrderId"}}`, encodeURIComponent(String(sellerFulfillmentOrderId)));
+                .replace('{sellerFulfillmentOrderId}', encodeURIComponent(String(sellerFulfillmentOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/fulfillment-outbound-api-2020-07-01/src/api-model/configuration.ts
+++ b/clients/fulfillment-outbound-api-2020-07-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/invoices-api-2024-06-19/src/api-model/api/invoices-api.ts
+++ b/clients/invoices-api-2024-06-19/src/api-model/api/invoices-api.ts
@@ -139,7 +139,7 @@ export const InvoicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'invoiceType' is not null or undefined
             assertParamExists('getGovernmentInvoiceDocument', 'invoiceType', invoiceType)
             const localVarPath = `/tax/invoices/2024-06-19/governmentInvoiceRequests/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -257,7 +257,7 @@ export const InvoicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'invoiceId' is not null or undefined
             assertParamExists('getInvoice', 'invoiceId', invoiceId)
             const localVarPath = `/tax/invoices/2024-06-19/invoices/{invoiceId}`
-                .replace(`{${"invoiceId"}}`, encodeURIComponent(String(invoiceId)));
+                .replace('{invoiceId}', encodeURIComponent(String(invoiceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -435,7 +435,7 @@ export const InvoicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'invoicesDocumentId' is not null or undefined
             assertParamExists('getInvoicesDocument', 'invoicesDocumentId', invoicesDocumentId)
             const localVarPath = `/tax/invoices/2024-06-19/documents/{invoicesDocumentId}`
-                .replace(`{${"invoicesDocumentId"}}`, encodeURIComponent(String(invoicesDocumentId)));
+                .replace('{invoicesDocumentId}', encodeURIComponent(String(invoicesDocumentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -468,7 +468,7 @@ export const InvoicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'exportId' is not null or undefined
             assertParamExists('getInvoicesExport', 'exportId', exportId)
             const localVarPath = `/tax/invoices/2024-06-19/exports/{exportId}`
-                .replace(`{${"exportId"}}`, encodeURIComponent(String(exportId)));
+                .replace('{exportId}', encodeURIComponent(String(exportId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/invoices-api-2024-06-19/src/api-model/configuration.ts
+++ b/clients/invoices-api-2024-06-19/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/listings-items-api-2020-09-01/src/api-model/api/listings-items-api.ts
+++ b/clients/listings-items-api-2020-09-01/src/api-model/api/listings-items-api.ts
@@ -51,8 +51,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('deleteListingsItem', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/listings/2020-09-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -103,8 +103,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'body' is not null or undefined
             assertParamExists('patchListingsItem', 'body', body)
             const localVarPath = `/listings/2020-09-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -157,8 +157,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'body' is not null or undefined
             assertParamExists('putListingsItem', 'body', body)
             const localVarPath = `/listings/2020-09-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/listings-items-api-2020-09-01/src/api-model/configuration.ts
+++ b/clients/listings-items-api-2020-09-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/listings-items-api-2021-08-01/src/api-model/api/listings-items-api.ts
+++ b/clients/listings-items-api-2021-08-01/src/api-model/api/listings-items-api.ts
@@ -55,8 +55,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('deleteListingsItem', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/listings/2021-08-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -105,8 +105,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getListingsItem', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/listings/2021-08-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -163,8 +163,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'body' is not null or undefined
             assertParamExists('patchListingsItem', 'body', body)
             const localVarPath = `/listings/2021-08-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -227,8 +227,8 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'body' is not null or undefined
             assertParamExists('putListingsItem', 'body', body)
             const localVarPath = `/listings/2021-08-01/items/{sellerId}/{sku}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)))
-                .replace(`{${"sku"}}`, encodeURIComponent(String(sku)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)))
+                .replace('{sku}', encodeURIComponent(String(sku)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -299,7 +299,7 @@ export const ListingsItemsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('searchListingsItems', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/listings/2021-08-01/items/{sellerId}`
-                .replace(`{${"sellerId"}}`, encodeURIComponent(String(sellerId)));
+                .replace('{sellerId}', encodeURIComponent(String(sellerId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/listings-items-api-2021-08-01/src/api-model/configuration.ts
+++ b/clients/listings-items-api-2021-08-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/listings-restrictions-api-2021-08-01/src/api-model/configuration.ts
+++ b/clients/listings-restrictions-api-2021-08-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/merchant-fulfillment-api-v0/src/api-model/api/merchant-fulfillment-api.ts
+++ b/clients/merchant-fulfillment-api-v0/src/api-model/api/merchant-fulfillment-api.ts
@@ -52,7 +52,7 @@ export const MerchantFulfillmentApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('cancelShipment', 'shipmentId', shipmentId)
             const localVarPath = `/mfn/v0/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -187,7 +187,7 @@ export const MerchantFulfillmentApiAxiosParamCreator = function (configuration?:
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipment', 'shipmentId', shipmentId)
             const localVarPath = `/mfn/v0/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/merchant-fulfillment-api-v0/src/api-model/configuration.ts
+++ b/clients/merchant-fulfillment-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/messaging-api-v1/src/api-model/api/messaging-api.ts
+++ b/clients/messaging-api-v1/src/api-model/api/messaging-api.ts
@@ -82,7 +82,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('confirmCustomizationDetails', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/confirmCustomizationDetails`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -127,7 +127,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createConfirmDeliveryDetails', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/confirmDeliveryDetails`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -172,7 +172,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createConfirmOrderDetails', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/confirmOrderDetails`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -217,7 +217,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createConfirmServiceDetails', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/confirmServiceDetails`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -262,7 +262,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createDigitalAccessKey', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/digitalAccessKey`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -307,7 +307,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createLegalDisclosure', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/legalDisclosure`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -352,7 +352,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createUnexpectedProblem', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/unexpectedProblem`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -397,7 +397,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createWarranty', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/warranty`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -439,7 +439,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getAttributes', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/attributes`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -479,7 +479,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getMessagingActionsForOrder', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -522,7 +522,7 @@ export const MessagingApiAxiosParamCreator = function (configuration?: Configura
             // verify required parameter 'body' is not null or undefined
             assertParamExists('sendInvoice', 'body', body)
             const localVarPath = `/messaging/v1/orders/{amazonOrderId}/messages/invoice`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/messaging-api-v1/src/api-model/configuration.ts
+++ b/clients/messaging-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/notifications-api-v1/src/api-model/api/notifications-api.ts
+++ b/clients/notifications-api-v1/src/api-model/api/notifications-api.ts
@@ -93,7 +93,7 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createSubscription', 'body', body)
             const localVarPath = `/notifications/v1/subscriptions/{notificationType}`
-                .replace(`{${"notificationType"}}`, encodeURIComponent(String(notificationType)));
+                .replace('{notificationType}', encodeURIComponent(String(notificationType)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -128,7 +128,7 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'destinationId' is not null or undefined
             assertParamExists('deleteDestination', 'destinationId', destinationId)
             const localVarPath = `/notifications/v1/destinations/{destinationId}`
-                .replace(`{${"destinationId"}}`, encodeURIComponent(String(destinationId)));
+                .replace('{destinationId}', encodeURIComponent(String(destinationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -164,8 +164,8 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'notificationType' is not null or undefined
             assertParamExists('deleteSubscriptionById', 'notificationType', notificationType)
             const localVarPath = `/notifications/v1/subscriptions/{notificationType}/{subscriptionId}`
-                .replace(`{${"subscriptionId"}}`, encodeURIComponent(String(subscriptionId)))
-                .replace(`{${"notificationType"}}`, encodeURIComponent(String(notificationType)));
+                .replace('{subscriptionId}', encodeURIComponent(String(subscriptionId)))
+                .replace('{notificationType}', encodeURIComponent(String(notificationType)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -198,7 +198,7 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'destinationId' is not null or undefined
             assertParamExists('getDestination', 'destinationId', destinationId)
             const localVarPath = `/notifications/v1/destinations/{destinationId}`
-                .replace(`{${"destinationId"}}`, encodeURIComponent(String(destinationId)));
+                .replace('{destinationId}', encodeURIComponent(String(destinationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -261,7 +261,7 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'notificationType' is not null or undefined
             assertParamExists('getSubscription', 'notificationType', notificationType)
             const localVarPath = `/notifications/v1/subscriptions/{notificationType}`
-                .replace(`{${"notificationType"}}`, encodeURIComponent(String(notificationType)));
+                .replace('{notificationType}', encodeURIComponent(String(notificationType)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -301,8 +301,8 @@ export const NotificationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'notificationType' is not null or undefined
             assertParamExists('getSubscriptionById', 'notificationType', notificationType)
             const localVarPath = `/notifications/v1/subscriptions/{notificationType}/{subscriptionId}`
-                .replace(`{${"subscriptionId"}}`, encodeURIComponent(String(subscriptionId)))
-                .replace(`{${"notificationType"}}`, encodeURIComponent(String(notificationType)));
+                .replace('{subscriptionId}', encodeURIComponent(String(subscriptionId)))
+                .replace('{notificationType}', encodeURIComponent(String(notificationType)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/notifications-api-v1/src/api-model/configuration.ts
+++ b/clients/notifications-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/orders-api-2026-01-01/src/api-model/api/orders-api.ts
+++ b/clients/orders-api-2026-01-01/src/api-model/api/orders-api.ts
@@ -43,7 +43,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrder', 'orderId', orderId)
             const localVarPath = `/orders/2026-01-01/orders/{orderId}`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/orders-api-2026-01-01/src/api-model/configuration.ts
+++ b/clients/orders-api-2026-01-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/orders-api-v0/src/api-model/api/orders-api.ts
+++ b/clients/orders-api-v0/src/api-model/api/orders-api.ts
@@ -65,7 +65,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'payload' is not null or undefined
             assertParamExists('confirmShipment', 'payload', payload)
             const localVarPath = `/orders/v0/orders/{orderId}/shipmentConfirmation`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -101,7 +101,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrder', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -135,7 +135,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderAddress', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}/address`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -169,7 +169,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderBuyerInfo', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}/buyerInfo`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -204,7 +204,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderItems', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}/orderItems`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -243,7 +243,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderItemsBuyerInfo', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}/orderItems/buyerInfo`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -280,7 +280,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'orderId' is not null or undefined
             assertParamExists('getOrderRegulatedInfo', 'orderId', orderId)
             const localVarPath = `/orders/v0/orders/{orderId}/regulatedInfo`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -453,7 +453,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'payload' is not null or undefined
             assertParamExists('updateShipmentStatus', 'payload', payload)
             const localVarPath = `/orders/v0/orders/{orderId}/shipment`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -491,7 +491,7 @@ export const OrdersApiAxiosParamCreator = function (configuration?: Configuratio
             // verify required parameter 'payload' is not null or undefined
             assertParamExists('updateVerificationStatus', 'payload', payload)
             const localVarPath = `/orders/v0/orders/{orderId}/regulatedInfo`
-                .replace(`{${"orderId"}}`, encodeURIComponent(String(orderId)));
+                .replace('{orderId}', encodeURIComponent(String(orderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/orders-api-v0/src/api-model/configuration.ts
+++ b/clients/orders-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/product-fees-api-v0/src/api-model/api/product-fees-api.ts
+++ b/clients/product-fees-api-v0/src/api-model/api/product-fees-api.ts
@@ -49,7 +49,7 @@ export const ProductFeesApiAxiosParamCreator = function (configuration?: Configu
             // verify required parameter 'body' is not null or undefined
             assertParamExists('getMyFeesEstimateForASIN', 'body', body)
             const localVarPath = `/products/fees/v0/items/{Asin}/feesEstimate`
-                .replace(`{${"Asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{Asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -87,7 +87,7 @@ export const ProductFeesApiAxiosParamCreator = function (configuration?: Configu
             // verify required parameter 'body' is not null or undefined
             assertParamExists('getMyFeesEstimateForSKU', 'body', body)
             const localVarPath = `/products/fees/v0/listings/{SellerSKU}/feesEstimate`
-                .replace(`{${"SellerSKU"}}`, encodeURIComponent(String(sellerSKU)));
+                .replace('{SellerSKU}', encodeURIComponent(String(sellerSKU)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/product-fees-api-v0/src/api-model/configuration.ts
+++ b/clients/product-fees-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/product-pricing-api-2022-05-01/src/api-model/configuration.ts
+++ b/clients/product-pricing-api-2022-05-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/product-pricing-api-v0/src/api-model/api/product-pricing-api.ts
+++ b/clients/product-pricing-api-v0/src/api-model/api/product-pricing-api.ts
@@ -115,7 +115,7 @@ export const ProductPricingApiAxiosParamCreator = function (configuration?: Conf
             // verify required parameter 'asin' is not null or undefined
             assertParamExists('getItemOffers', 'asin', asin)
             const localVarPath = `/products/pricing/v0/items/{Asin}/offers`
-                .replace(`{${"Asin"}}`, encodeURIComponent(String(asin)));
+                .replace('{Asin}', encodeURIComponent(String(asin)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -201,7 +201,7 @@ export const ProductPricingApiAxiosParamCreator = function (configuration?: Conf
             // verify required parameter 'sellerSKU' is not null or undefined
             assertParamExists('getListingOffers', 'sellerSKU', sellerSKU)
             const localVarPath = `/products/pricing/v0/listings/{SellerSKU}/offers`
-                .replace(`{${"SellerSKU"}}`, encodeURIComponent(String(sellerSKU)));
+                .replace('{SellerSKU}', encodeURIComponent(String(sellerSKU)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/product-pricing-api-v0/src/api-model/configuration.ts
+++ b/clients/product-pricing-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/product-type-definitions-api-2020-09-01/src/api-model/api/product-type-definitions-api.ts
+++ b/clients/product-type-definitions-api-2020-09-01/src/api-model/api/product-type-definitions-api.ts
@@ -50,7 +50,7 @@ export const ProductTypeDefinitionsApiAxiosParamCreator = function (configuratio
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getDefinitionsProductType', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/definitions/2020-09-01/productTypes/{productType}`
-                .replace(`{${"productType"}}`, encodeURIComponent(String(productType)));
+                .replace('{productType}', encodeURIComponent(String(productType)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/product-type-definitions-api-2020-09-01/src/api-model/configuration.ts
+++ b/clients/product-type-definitions-api-2020-09-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/replenishment-api-2022-11-07/src/api-model/configuration.ts
+++ b/clients/replenishment-api-2022-11-07/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/reports-api-2021-06-30/src/api-model/api/reports-api.ts
+++ b/clients/reports-api-2021-06-30/src/api-model/api/reports-api.ts
@@ -56,7 +56,7 @@ export const ReportsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'reportId' is not null or undefined
             assertParamExists('cancelReport', 'reportId', reportId)
             const localVarPath = `/reports/2021-06-30/reports/{reportId}`
-                .replace(`{${"reportId"}}`, encodeURIComponent(String(reportId)));
+                .replace('{reportId}', encodeURIComponent(String(reportId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -89,7 +89,7 @@ export const ReportsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'reportScheduleId' is not null or undefined
             assertParamExists('cancelReportSchedule', 'reportScheduleId', reportScheduleId)
             const localVarPath = `/reports/2021-06-30/schedules/{reportScheduleId}`
-                .replace(`{${"reportScheduleId"}}`, encodeURIComponent(String(reportScheduleId)));
+                .replace('{reportScheduleId}', encodeURIComponent(String(reportScheduleId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -190,7 +190,7 @@ export const ReportsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'reportId' is not null or undefined
             assertParamExists('getReport', 'reportId', reportId)
             const localVarPath = `/reports/2021-06-30/reports/{reportId}`
-                .replace(`{${"reportId"}}`, encodeURIComponent(String(reportId)));
+                .replace('{reportId}', encodeURIComponent(String(reportId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -224,7 +224,7 @@ export const ReportsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'reportDocumentId' is not null or undefined
             assertParamExists('getReportDocument', 'reportDocumentId', reportDocumentId)
             const localVarPath = `/reports/2021-06-30/documents/{reportDocumentId}`
-                .replace(`{${"reportDocumentId"}}`, encodeURIComponent(String(reportDocumentId)));
+                .replace('{reportDocumentId}', encodeURIComponent(String(reportDocumentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -261,7 +261,7 @@ export const ReportsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'reportScheduleId' is not null or undefined
             assertParamExists('getReportSchedule', 'reportScheduleId', reportScheduleId)
             const localVarPath = `/reports/2021-06-30/schedules/{reportScheduleId}`
-                .replace(`{${"reportScheduleId"}}`, encodeURIComponent(String(reportScheduleId)));
+                .replace('{reportScheduleId}', encodeURIComponent(String(reportScheduleId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/reports-api-2021-06-30/src/api-model/configuration.ts
+++ b/clients/reports-api-2021-06-30/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/sales-api-v1/src/api-model/configuration.ts
+++ b/clients/sales-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/seller-wallet-api-2024-03-01/src/api-model/api/seller-wallet-api.ts
+++ b/clients/seller-wallet-api-2024-03-01/src/api-model/api/seller-wallet-api.ts
@@ -174,7 +174,7 @@ export const SellerWalletApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('deleteScheduleTransaction', 'marketplaceId', marketplaceId)
             const localVarPath = `/finances/transfers/wallet/2024-03-01/transferSchedules/{transferScheduleId}`
-                .replace(`{${"transferScheduleId"}}`, encodeURIComponent(String(transferScheduleId)));
+                .replace('{transferScheduleId}', encodeURIComponent(String(transferScheduleId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -215,7 +215,7 @@ export const SellerWalletApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getAccount', 'marketplaceId', marketplaceId)
             const localVarPath = `/finances/transfers/wallet/2024-03-01/accounts/{accountId}`
-                .replace(`{${"accountId"}}`, encodeURIComponent(String(accountId)));
+                .replace('{accountId}', encodeURIComponent(String(accountId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -256,7 +256,7 @@ export const SellerWalletApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getTransaction', 'marketplaceId', marketplaceId)
             const localVarPath = `/finances/transfers/wallet/2024-03-01/transactions/{transactionId}`
-                .replace(`{${"transactionId"}}`, encodeURIComponent(String(transactionId)));
+                .replace('{transactionId}', encodeURIComponent(String(transactionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -369,7 +369,7 @@ export const SellerWalletApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('getTransferSchedule', 'marketplaceId', marketplaceId)
             const localVarPath = `/finances/transfers/wallet/2024-03-01/transferSchedules/{transferScheduleId}`
-                .replace(`{${"transferScheduleId"}}`, encodeURIComponent(String(transferScheduleId)));
+                .replace('{transferScheduleId}', encodeURIComponent(String(transferScheduleId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -410,7 +410,7 @@ export const SellerWalletApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'marketplaceId' is not null or undefined
             assertParamExists('listAccountBalances', 'marketplaceId', marketplaceId)
             const localVarPath = `/finances/transfers/wallet/2024-03-01/accounts/{accountId}/balance`
-                .replace(`{${"accountId"}}`, encodeURIComponent(String(accountId)));
+                .replace('{accountId}', encodeURIComponent(String(accountId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/seller-wallet-api-2024-03-01/src/api-model/configuration.ts
+++ b/clients/seller-wallet-api-2024-03-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/sellers-api-v1/src/api-model/configuration.ts
+++ b/clients/sellers-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/services-api-v1/src/api-model/api/services-api.ts
+++ b/clients/services-api-v1/src/api-model/api/services-api.ts
@@ -91,7 +91,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('addAppointmentForServiceJobByServiceJobId', 'body', body)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/appointments`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -132,8 +132,8 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('assignAppointmentResources', 'body', body)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/appointments/{appointmentId}/resources`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)))
-                .replace(`{${"appointmentId"}}`, encodeURIComponent(String(appointmentId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)))
+                .replace('{appointmentId}', encodeURIComponent(String(appointmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -171,7 +171,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('cancelReservation', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/service/v1/reservation/{reservationId}`
-                .replace(`{${"reservationId"}}`, encodeURIComponent(String(reservationId)));
+                .replace('{reservationId}', encodeURIComponent(String(reservationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -211,7 +211,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'cancellationReasonCode' is not null or undefined
             assertParamExists('cancelServiceJobByServiceJobId', 'cancellationReasonCode', cancellationReasonCode)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/cancellations`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -248,7 +248,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'serviceJobId' is not null or undefined
             assertParamExists('completeServiceJobByServiceJobId', 'serviceJobId', serviceJobId)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/completions`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -421,7 +421,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getAppointmmentSlotsByJobId', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/appointmentSlots`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -473,7 +473,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('getFixedSlotCapacity', 'body', body)
             const localVarPath = `/service/v1/serviceResources/{resourceId}/capacity/fixed`
-                .replace(`{${"resourceId"}}`, encodeURIComponent(String(resourceId)));
+                .replace('{resourceId}', encodeURIComponent(String(resourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -523,7 +523,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('getRangeSlotCapacity', 'body', body)
             const localVarPath = `/service/v1/serviceResources/{resourceId}/capacity/range`
-                .replace(`{${"resourceId"}}`, encodeURIComponent(String(resourceId)));
+                .replace('{resourceId}', encodeURIComponent(String(resourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -566,7 +566,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'serviceJobId' is not null or undefined
             assertParamExists('getServiceJobByServiceJobId', 'serviceJobId', serviceJobId)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -716,8 +716,8 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('rescheduleAppointmentForServiceJobByServiceJobId', 'body', body)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/appointments/{appointmentId}`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)))
-                .replace(`{${"appointmentId"}}`, encodeURIComponent(String(appointmentId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)))
+                .replace('{appointmentId}', encodeURIComponent(String(appointmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -758,8 +758,8 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('setAppointmentFulfillmentData', 'body', body)
             const localVarPath = `/service/v1/serviceJobs/{serviceJobId}/appointments/{appointmentId}/fulfillment`
-                .replace(`{${"serviceJobId"}}`, encodeURIComponent(String(serviceJobId)))
-                .replace(`{${"appointmentId"}}`, encodeURIComponent(String(appointmentId)));
+                .replace('{serviceJobId}', encodeURIComponent(String(serviceJobId)))
+                .replace('{appointmentId}', encodeURIComponent(String(appointmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -800,7 +800,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateReservation', 'body', body)
             const localVarPath = `/service/v1/reservation/{reservationId}`
-                .replace(`{${"reservationId"}}`, encodeURIComponent(String(reservationId)));
+                .replace('{reservationId}', encodeURIComponent(String(reservationId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -845,7 +845,7 @@ export const ServicesApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('updateSchedule', 'body', body)
             const localVarPath = `/service/v1/serviceResources/{resourceId}/schedules`
-                .replace(`{${"resourceId"}}`, encodeURIComponent(String(resourceId)));
+                .replace('{resourceId}', encodeURIComponent(String(resourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/services-api-v1/src/api-model/configuration.ts
+++ b/clients/services-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/shipment-invoicing-api-v0/src/api-model/api/shipment-invoicing-api.ts
+++ b/clients/shipment-invoicing-api-v0/src/api-model/api/shipment-invoicing-api.ts
@@ -44,7 +44,7 @@ export const ShipmentInvoicingApiAxiosParamCreator = function (configuration?: C
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getInvoiceStatus', 'shipmentId', shipmentId)
             const localVarPath = `/fba/outbound/brazil/v0/shipments/{shipmentId}/invoice/status`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -77,7 +77,7 @@ export const ShipmentInvoicingApiAxiosParamCreator = function (configuration?: C
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipmentDetails', 'shipmentId', shipmentId)
             const localVarPath = `/fba/outbound/brazil/v0/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -113,7 +113,7 @@ export const ShipmentInvoicingApiAxiosParamCreator = function (configuration?: C
             // verify required parameter 'body' is not null or undefined
             assertParamExists('submitInvoice', 'body', body)
             const localVarPath = `/fba/outbound/brazil/v0/shipments/{shipmentId}/invoice`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/shipment-invoicing-api-v0/src/api-model/configuration.ts
+++ b/clients/shipment-invoicing-api-v0/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/shipping-api-v1/src/api-model/api/shipping-api.ts
+++ b/clients/shipping-api-v1/src/api-model/api/shipping-api.ts
@@ -64,7 +64,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('cancelShipment', 'shipmentId', shipmentId)
             const localVarPath = `/shipping/v1/shipments/{shipmentId}/cancel`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -194,7 +194,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('getShipment', 'shipmentId', shipmentId)
             const localVarPath = `/shipping/v1/shipments/{shipmentId}`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -227,7 +227,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'trackingId' is not null or undefined
             assertParamExists('getTrackingInformation', 'trackingId', trackingId)
             const localVarPath = `/shipping/v1/tracking/{trackingId}`
-                .replace(`{${"trackingId"}}`, encodeURIComponent(String(trackingId)));
+                .replace('{trackingId}', encodeURIComponent(String(trackingId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -263,7 +263,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('purchaseLabels', 'body', body)
             const localVarPath = `/shipping/v1/shipments/{shipmentId}/purchaseLabels`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -338,8 +338,8 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('retrieveShippingLabel', 'body', body)
             const localVarPath = `/shipping/v1/shipments/{shipmentId}/containers/{trackingId}/label`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)))
-                .replace(`{${"trackingId"}}`, encodeURIComponent(String(trackingId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)))
+                .replace('{trackingId}', encodeURIComponent(String(trackingId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/shipping-api-v1/src/api-model/configuration.ts
+++ b/clients/shipping-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/shipping-api-v2/src/api-model/api/shipping-api.ts
+++ b/clients/shipping-api-v2/src/api-model/api/shipping-api.ts
@@ -99,7 +99,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'shipmentId' is not null or undefined
             assertParamExists('cancelShipment', 'shipmentId', shipmentId)
             const localVarPath = `/shipping/v2/shipments/{shipmentId}/cancel`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -434,7 +434,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'collectionFormId' is not null or undefined
             assertParamExists('getCollectionForm', 'collectionFormId', collectionFormId)
             const localVarPath = `/shipping/v2/collectionForms/{collectionFormId}`
-                .replace(`{${"collectionFormId"}}`, encodeURIComponent(String(collectionFormId)));
+                .replace('{collectionFormId}', encodeURIComponent(String(collectionFormId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -552,7 +552,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'packageClientReferenceId' is not null or undefined
             assertParamExists('getShipmentDocuments', 'packageClientReferenceId', packageClientReferenceId)
             const localVarPath = `/shipping/v2/shipments/{shipmentId}/documents`
-                .replace(`{${"shipmentId"}}`, encodeURIComponent(String(shipmentId)));
+                .replace('{shipmentId}', encodeURIComponent(String(shipmentId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -689,7 +689,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('linkCarrierAccount', 'body', body)
             const localVarPath = `/shipping/v2/carrierAccounts/{carrierId}`
-                .replace(`{${"carrierId"}}`, encodeURIComponent(String(carrierId)));
+                .replace('{carrierId}', encodeURIComponent(String(carrierId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -731,7 +731,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('linkCarrierAccount_1', 'body', body)
             const localVarPath = `/shipping/v2/carrierAccounts/{carrierId}`
-                .replace(`{${"carrierId"}}`, encodeURIComponent(String(carrierId)));
+                .replace('{carrierId}', encodeURIComponent(String(carrierId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -891,7 +891,7 @@ export const ShippingApiAxiosParamCreator = function (configuration?: Configurat
             // verify required parameter 'body' is not null or undefined
             assertParamExists('unlinkCarrierAccount', 'body', body)
             const localVarPath = `/shipping/v2/carrierAccounts/{carrierId}/unlink`
-                .replace(`{${"carrierId"}}`, encodeURIComponent(String(carrierId)));
+                .replace('{carrierId}', encodeURIComponent(String(carrierId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/shipping-api-v2/src/api-model/configuration.ts
+++ b/clients/shipping-api-v2/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/solicitations-api-v1/src/api-model/api/solicitations-api.ts
+++ b/clients/solicitations-api-v1/src/api-model/api/solicitations-api.ts
@@ -43,7 +43,7 @@ export const SolicitationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('createProductReviewAndSellerFeedbackSolicitation', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/solicitations/v1/orders/{amazonOrderId}/solicitations/productReviewAndSellerFeedback`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -83,7 +83,7 @@ export const SolicitationsApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'marketplaceIds' is not null or undefined
             assertParamExists('getSolicitationActionsForOrder', 'marketplaceIds', marketplaceIds)
             const localVarPath = `/solicitations/v1/orders/{amazonOrderId}`
-                .replace(`{${"amazonOrderId"}}`, encodeURIComponent(String(amazonOrderId)));
+                .replace('{amazonOrderId}', encodeURIComponent(String(amazonOrderId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/solicitations-api-v1/src/api-model/configuration.ts
+++ b/clients/solicitations-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/supply-sources-api-2020-07-01/src/api-model/api/supply-sources-api.ts
+++ b/clients/supply-sources-api-2020-07-01/src/api-model/api/supply-sources-api.ts
@@ -50,7 +50,7 @@ export const SupplySourcesApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'supplySourceId' is not null or undefined
             assertParamExists('archiveSupplySource', 'supplySourceId', supplySourceId)
             const localVarPath = `/supplySources/2020-07-01/supplySources/{supplySourceId}`
-                .replace(`{${"supplySourceId"}}`, encodeURIComponent(String(supplySourceId)));
+                .replace('{supplySourceId}', encodeURIComponent(String(supplySourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -117,7 +117,7 @@ export const SupplySourcesApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'supplySourceId' is not null or undefined
             assertParamExists('getSupplySource', 'supplySourceId', supplySourceId)
             const localVarPath = `/supplySources/2020-07-01/supplySources/{supplySourceId}`
-                .replace(`{${"supplySourceId"}}`, encodeURIComponent(String(supplySourceId)));
+                .replace('{supplySourceId}', encodeURIComponent(String(supplySourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -190,7 +190,7 @@ export const SupplySourcesApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'supplySourceId' is not null or undefined
             assertParamExists('updateSupplySource', 'supplySourceId', supplySourceId)
             const localVarPath = `/supplySources/2020-07-01/supplySources/{supplySourceId}`
-                .replace(`{${"supplySourceId"}}`, encodeURIComponent(String(supplySourceId)));
+                .replace('{supplySourceId}', encodeURIComponent(String(supplySourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -226,7 +226,7 @@ export const SupplySourcesApiAxiosParamCreator = function (configuration?: Confi
             // verify required parameter 'supplySourceId' is not null or undefined
             assertParamExists('updateSupplySourceStatus', 'supplySourceId', supplySourceId)
             const localVarPath = `/supplySources/2020-07-01/supplySources/{supplySourceId}/status`
-                .replace(`{${"supplySourceId"}}`, encodeURIComponent(String(supplySourceId)));
+                .replace('{supplySourceId}', encodeURIComponent(String(supplySourceId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/supply-sources-api-2020-07-01/src/api-model/configuration.ts
+++ b/clients/supply-sources-api-2020-07-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/tokens-api-2021-03-01/src/api-model/configuration.ts
+++ b/clients/tokens-api-2021-03-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/uploads-api-2020-11-01/src/api-model/api/uploads-api.ts
+++ b/clients/uploads-api-2020-11-01/src/api-model/api/uploads-api.ts
@@ -45,7 +45,7 @@ export const UploadsApiAxiosParamCreator = function (configuration?: Configurati
             // verify required parameter 'resource' is not null or undefined
             assertParamExists('createUploadDestinationForResource', 'resource', resource)
             const localVarPath = `/uploads/2020-11-01/uploadDestinations/{resource}`
-                .replace(`{${"resource"}}`, encodeURIComponent(String(resource)));
+                .replace('{resource}', encodeURIComponent(String(resource)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/uploads-api-2020-11-01/src/api-model/configuration.ts
+++ b/clients/uploads-api-2020-11-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vehicles-api-2024-11-01/src/api-model/configuration.ts
+++ b/clients/vehicles-api-2024-11-01/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/src/api-model/api/vendor-direct-fulfillment-inventory-api.ts
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/src/api-model/api/vendor-direct-fulfillment-inventory-api.ts
@@ -43,7 +43,7 @@ export const VendorDirectFulfillmentInventoryApiAxiosParamCreator = function (co
             // verify required parameter 'body' is not null or undefined
             assertParamExists('submitInventoryUpdate', 'body', body)
             const localVarPath = `/vendor/directFulfillment/inventory/v1/warehouses/{warehouseId}/items`
-                .replace(`{${"warehouseId"}}`, encodeURIComponent(String(warehouseId)));
+                .replace('{warehouseId}', encodeURIComponent(String(warehouseId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-orders-api.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-orders-api.ts
@@ -46,7 +46,7 @@ export const VendorDirectFulfillmentOrdersApiAxiosParamCreator = function (confi
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getOrder', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/orders/2021-12-28/purchaseOrders/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-orders-api-v1/src/api-model/api/vendor-direct-fulfillment-orders-api.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/src/api-model/api/vendor-direct-fulfillment-orders-api.ts
@@ -44,7 +44,7 @@ export const VendorDirectFulfillmentOrdersApiAxiosParamCreator = function (confi
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getOrder', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/orders/v1/purchaseOrders/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-orders-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-payments-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/src/api-model/api/vendor-direct-fulfillment-sandbox-test-data-api.ts
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/src/api-model/api/vendor-direct-fulfillment-sandbox-test-data-api.ts
@@ -78,7 +78,7 @@ export const VendorDirectFulfillmentSandboxTestDataApiAxiosParamCreator = functi
             // verify required parameter 'transactionId' is not null or undefined
             assertParamExists('getOrderScenarios', 'transactionId', transactionId)
             const localVarPath = `/vendor/directFulfillment/sandbox/2021-10-28/transactions/{transactionId}`
-                .replace(`{${"transactionId"}}`, encodeURIComponent(String(transactionId)));
+                .replace('{transactionId}', encodeURIComponent(String(transactionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-shipping-api.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-shipping-api.ts
@@ -103,7 +103,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'body' is not null or undefined
             assertParamExists('createShippingLabels', 'body', body)
             const localVarPath = `/vendor/directFulfillment/shipping/2021-12-28/shippingLabels/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -139,7 +139,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getCustomerInvoice', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/2021-12-28/customerInvoices/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -241,7 +241,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getPackingSlip', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/2021-12-28/packingSlips/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -343,7 +343,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getShippingLabel', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/2021-12-28/shippingLabels/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/src/api-model/api/vendor-direct-fulfillment-shipping-api.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/src/api-model/api/vendor-direct-fulfillment-shipping-api.ts
@@ -60,7 +60,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getCustomerInvoice', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/v1/customerInvoices/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -160,7 +160,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getPackingSlip', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/v1/packingSlips/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;
@@ -260,7 +260,7 @@ export const VendorDirectFulfillmentShippingApiAxiosParamCreator = function (con
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getShippingLabel', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/directFulfillment/shipping/v1/shippingLabels/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-transactions-api.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/src/api-model/api/vendor-direct-fulfillment-transactions-api.ts
@@ -40,7 +40,7 @@ export const VendorDirectFulfillmentTransactionsApiAxiosParamCreator = function 
             // verify required parameter 'transactionId' is not null or undefined
             assertParamExists('getTransactionStatus', 'transactionId', transactionId)
             const localVarPath = `/vendor/directFulfillment/transactions/2021-12-28/transactions/{transactionId}`
-                .replace(`{${"transactionId"}}`, encodeURIComponent(String(transactionId)));
+                .replace('{transactionId}', encodeURIComponent(String(transactionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/src/api-model/api/vendor-direct-fulfillment-transactions-api.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/src/api-model/api/vendor-direct-fulfillment-transactions-api.ts
@@ -38,7 +38,7 @@ export const VendorDirectFulfillmentTransactionsApiAxiosParamCreator = function 
             // verify required parameter 'transactionId' is not null or undefined
             assertParamExists('getTransactionStatus', 'transactionId', transactionId)
             const localVarPath = `/vendor/directFulfillment/transactions/v1/transactions/{transactionId}`
-                .replace(`{${"transactionId"}}`, encodeURIComponent(String(transactionId)));
+                .replace('{transactionId}', encodeURIComponent(String(transactionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-invoices-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-invoices-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-orders-api-v1/src/api-model/api/vendor-orders-api.ts
+++ b/clients/vendor-orders-api-v1/src/api-model/api/vendor-orders-api.ts
@@ -46,7 +46,7 @@ export const VendorOrdersApiAxiosParamCreator = function (configuration?: Config
             // verify required parameter 'purchaseOrderNumber' is not null or undefined
             assertParamExists('getPurchaseOrder', 'purchaseOrderNumber', purchaseOrderNumber)
             const localVarPath = `/vendor/orders/v1/purchaseOrders/{purchaseOrderNumber}`
-                .replace(`{${"purchaseOrderNumber"}}`, encodeURIComponent(String(purchaseOrderNumber)));
+                .replace('{purchaseOrderNumber}', encodeURIComponent(String(purchaseOrderNumber)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-orders-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-orders-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-shipments-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-shipments-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/clients/vendor-transaction-status-api-v1/src/api-model/api/vendor-transaction-status-api.ts
+++ b/clients/vendor-transaction-status-api-v1/src/api-model/api/vendor-transaction-status-api.ts
@@ -38,7 +38,7 @@ export const VendorTransactionStatusApiAxiosParamCreator = function (configurati
             // verify required parameter 'transactionId' is not null or undefined
             assertParamExists('getTransaction', 'transactionId', transactionId)
             const localVarPath = `/vendor/transactions/v1/transactions/{transactionId}`
-                .replace(`{${"transactionId"}}`, encodeURIComponent(String(transactionId)));
+                .replace('{transactionId}', encodeURIComponent(String(transactionId)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
             let baseOptions;

--- a/clients/vendor-transaction-status-api-v1/src/api-model/configuration.ts
+++ b/clients/vendor-transaction-status-api-v1/src/api-model/configuration.ts
@@ -115,7 +115,7 @@ export class Configuration {
      * @return True if the given MIME is JSON, false otherwise.
      */
     public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+        const jsonMime: RegExp = /^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$/i;
+        return mime !== null && jsonMime.test(mime);
     }
 }

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,6 +2,6 @@
   "$schema": "codegen/node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.21.0"
+    "version": "7.22.0"
   }
 }


### PR DESCRIPTION
Bumps `@openapitools/openapi-generator-cli` from 7.21.0 to 7.22.0 and regenerates all clients.

Generated diff is purely cosmetic — no behavior change:

- `api-model/api/*.ts`: path-param substitution simplified, e.g. `` `{${"orderId"}}` `` → `'{orderId}'`
- `api-model/configuration.ts`: `isJsonMime` switched to a regex literal and dropped the redundant `application/json-patch+json` special case (the regex already matches `+json` suffixes)