### PR TITLE
docs: use orders-api-2026-01-01 in samples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ pnpm codegen schemas      # generate schemas only
 ┌─────────────────────────────────────────────────────┐
 │                   User Code                         │
 ├─────────────────────────────────────────────────────┤
-│  @sp-api-sdk/orders-api-v0  (or any client)         │
+│  @sp-api-sdk/orders-api-2026-01-01  (or any client) │
 │    └── extends generated API class                  │
 ├─────────────────────────────────────────────────────┤
 │  @sp-api-sdk/common                                 │

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ This SDK supports the following features:
 Install the authentication package and the API client(s) you need:
 
 ```sh
-npm install @sp-api-sdk/auth @sp-api-sdk/orders-api-v0
+npm install @sp-api-sdk/auth @sp-api-sdk/orders-api-2026-01-01
 ```
 
 ### Usage
 
 ```javascript
 import { SellingPartnerApiAuth } from "@sp-api-sdk/auth";
-import { OrdersApiClient } from "@sp-api-sdk/orders-api-v0";
+import { OrdersApiClient } from "@sp-api-sdk/orders-api-2026-01-01";
 
 const auth = new SellingPartnerApiAuth({
   clientId: process.env.LWA_CLIENT_ID,
@@ -64,9 +64,9 @@ const client = new OrdersApiClient({
   region: "eu",
 });
 
-const { data: orders } = await client.getOrders({
+const { data } = await client.searchOrders({
   marketplaceIds: ["A1PA6795UKMFR9"],
-  createdAfter: "2024-01-01T00:00:00Z",
+  createdAfter: "2026-01-01T00:00:00Z",
 });
 ```
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -98,12 +98,12 @@ API errors are wrapped in `SellingPartnerApiError`, which extends `AxiosError` a
 import { SellingPartnerApiError } from "@sp-api-sdk/common";
 
 try {
-  await client.getOrders({ marketplaceIds: ["A1PA6795UKMFR9"] });
+  await client.searchOrders({ marketplaceIds: ["A1PA6795UKMFR9"] });
 } catch (error) {
   if (error instanceof SellingPartnerApiError) {
-    console.error(error.message); // e.g. "orders (v0) error: Response code 403"
+    console.error(error.message); // e.g. "orders (2026-01-01) error: Response code 403"
     console.error(error.apiName); // e.g. "orders"
-    console.error(error.apiVersion); // e.g. "v0"
+    console.error(error.apiVersion); // e.g. "2026-01-01"
     console.error(error.innerMessage); // Original axios error message
   }
 }


### PR DESCRIPTION
## Summary
- `orders-api-v0` is deprecated; switch the README usage sample to the latest `orders-api-2026-01-01` client (and rename `getOrders` → `searchOrders`).
- Update the `@sp-api-sdk/common` error-handling snippet to use the new method name and `2026-01-01` apiVersion.
- Update the architecture-diagram example in `CLAUDE.md` to reference the latest client.

The "Clients" list in the README still legitimately enumerates every published package (older versions included), so it was left alone.

## Test plan
- [x] Rendered README sample compiles against `@sp-api-sdk/orders-api-2026-01-01`.