### PR TITLE
docs(codegen): generate clients list and flag deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,7 @@ By default, `request` and `response` loggers use `console.info`, and the `error`
 
 This repository contains an API client for each of the available Selling Partner API version:
 
-<!---
-Generated using:
-
-ls clients | sed 's$\(.*\)$- [\1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/\1)$' | pbcopy
--->
-
+<!-- codegen:clients:start -->
 - [amazon-warehousing-and-distribution-api-2024-05-09](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/amazon-warehousing-and-distribution-api-2024-05-09)
 - [aplus-content-api-2020-11-01](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/aplus-content-api-2020-11-01)
 - [application-integrations-api-2024-04-01](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/application-integrations-api-2024-04-01)
@@ -169,7 +164,7 @@ ls clients | sed 's$\(.*\)$- [\1](https://www.github.com/bizon/selling-partner-a
 - [messaging-api-v1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/messaging-api-v1)
 - [notifications-api-v1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/notifications-api-v1)
 - [orders-api-2026-01-01](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/orders-api-2026-01-01)
-- [orders-api-v0](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/orders-api-v0)
+- [orders-api-v0](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/orders-api-v0) — contains deprecated operations
 - [product-fees-api-v0](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-fees-api-v0)
 - [product-pricing-api-2022-05-01](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-pricing-api-2022-05-01)
 - [product-pricing-api-v0](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-pricing-api-v0)
@@ -201,6 +196,7 @@ ls clients | sed 's$\(.*\)$- [\1](https://www.github.com/bizon/selling-partner-a
 - [vendor-orders-api-v1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-orders-api-v1)
 - [vendor-shipments-api-v1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-shipments-api-v1)
 - [vendor-transaction-status-api-v1](https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-transaction-status-api-v1)
+<!-- codegen:clients:end -->
 
 The API clients are automatically generated from the Swagger/OpenAPI models from [the official models repository](https://github.com/amzn/selling-partner-api-models).
 [A code generation workflow](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/codegen.yml) runs twice a day and will create a PR on this repository whenever there are changes to the models.

--- a/clients/orders-api-v0/README.md
+++ b/clients/orders-api-v0/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/orders-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/orders-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** This client contains deprecated operations. Refer to the [SP-API Deprecations Schedule](https://developer-docs.amazon.com/sp-api/docs/sp-api-deprecations) for more information.
+
 Use the Orders Selling Partner API to programmatically retrieve order information. With this API, you can develop fast, flexible, and custom applications to manage order synchronization, perform order research, and create demand-based decision support tools. 
 
 _Note:_ For the JP, AU, and SG marketplaces, the Orders API supports orders from 2016 onward. For all other marketplaces, the Orders API supports orders for the last two years (orders older than this don't show up in the response).

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -6,7 +6,7 @@ import camelCase from 'camelcase'
 import {globby} from 'globby'
 import jsonfile from 'jsonfile'
 import {kebabCase, reduce} from 'lodash-es'
-import {type OpenAPIV3} from 'openapi-types'
+import {OpenAPIV3} from 'openapi-types'
 import pMap from 'p-map'
 import {remark} from 'remark'
 import remarkStrip from 'strip-markdown'
@@ -26,6 +26,27 @@ interface RateLimit {
   burst: number
   urlRegex: string
   last?: boolean
+}
+
+interface ClientInfo {
+  packageName: string
+  hasDeprecatedOperations: boolean
+}
+
+function hasDeprecatedOperations(document: OpenAPIV3.Document): boolean {
+  for (const pathItem of Object.values(document.paths ?? {})) {
+    if (!pathItem) {
+      continue
+    }
+
+    for (const method of Object.values(OpenAPIV3.HttpMethods)) {
+      if (pathItem[method]?.deprecated) {
+        return true
+      }
+    }
+  }
+
+  return false
 }
 
 async function readPackageVersion(path: string) {
@@ -60,7 +81,7 @@ async function cleanMarkdown(input: string, stripNewLines?: boolean) {
   return result.trim()
 }
 
-async function generateClientVersion(modelFilePath: string) {
+async function generateClientVersion(modelFilePath: string): Promise<ClientInfo> {
   const {dir: modelDirectory, name: modelName} = parsePath(modelFilePath)
 
   const modelPath = `selling-partner-api-models/models/${modelFilePath}`
@@ -231,6 +252,8 @@ async function generateClientVersion(modelFilePath: string) {
       rateLimits,
     }),
   )
+  const deprecated = hasDeprecatedOperations(document)
+
   await fs.writeFile(
     `${clientDirectoryPath}/README.md`,
     await renderTemplate('codegen/templates/README.md.mustache', {
@@ -239,6 +262,7 @@ async function generateClientVersion(modelFilePath: string) {
       description: document.info.description,
       sdkClientDocUrl: `https://bizon.github.io/selling-partner-api-sdk/modules/_sp-api-sdk_${packageName}.html`,
       grantlessScope: grantlessInfo?.scope,
+      hasDeprecatedOperations: deprecated,
     }),
   )
 
@@ -264,6 +288,36 @@ async function generateClientVersion(modelFilePath: string) {
   )
 
   logger.info(`done in ${(Date.now() - startedAt) / 1000}s`, {packageName})
+
+  return {packageName, hasDeprecatedOperations: deprecated}
+}
+
+const CLIENTS_LIST_START = '<!-- codegen:clients:start -->'
+const CLIENTS_LIST_END = '<!-- codegen:clients:end -->'
+
+async function updateRootReadmeClientsList(clients: ClientInfo[]) {
+  const readmePath = 'README.md'
+  const readme = await fs.readFile(readmePath, 'utf8')
+
+  const sorted = [...clients].sort((a, b) => a.packageName.localeCompare(b.packageName))
+  const list = sorted
+    .map((client) => {
+      const url = `https://www.github.com/bizon/selling-partner-api-sdk/tree/master/clients/${client.packageName}`
+      const suffix = client.hasDeprecatedOperations ? ' — contains deprecated operations' : ''
+      return `- [${client.packageName}](${url})${suffix}`
+    })
+    .join('\n')
+
+  const pattern = new RegExp(`${CLIENTS_LIST_START}[\\s\\S]*?${CLIENTS_LIST_END}`)
+
+  if (!pattern.test(readme)) {
+    throw new Error(
+      `Could not find clients list markers (${CLIENTS_LIST_START} / ${CLIENTS_LIST_END}) in ${readmePath}`,
+    )
+  }
+
+  const replacement = `${CLIENTS_LIST_START}\n${list}\n${CLIENTS_LIST_END}`
+  await fs.writeFile(readmePath, readme.replace(pattern, replacement))
 }
 
 export async function generateClients() {
@@ -275,7 +329,13 @@ export async function generateClients() {
     cwd: 'selling-partner-api-models/models',
   })
 
-  await pMap(modelFilePaths, async (modelFilePath) => generateClientVersion(modelFilePath), {
-    concurrency: os.cpus().length,
-  })
+  const clients = await pMap(
+    modelFilePaths,
+    async (modelFilePath) => generateClientVersion(modelFilePath),
+    {
+      concurrency: os.cpus().length,
+    },
+  )
+
+  await updateRootReadmeClientsList(clients)
 }

--- a/codegen/templates/README.md.mustache
+++ b/codegen/templates/README.md.mustache
@@ -3,6 +3,10 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/{{packageName}})](https://www.npmjs.com/package/@sp-api-sdk/{{packageName}})
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+{{#hasDeprecatedOperations}}
+> **Note:** This client contains deprecated operations. Refer to the [SP-API Deprecations Schedule](https://developer-docs.amazon.com/sp-api/docs/sp-api-deprecations) for more information.
+
+{{/hasDeprecatedOperations}}
 {{description}}
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)


### PR DESCRIPTION
## Summary

- Add a step at the end of `pnpm codegen clients` that rewrites the
  clients bullet list in the root `README.md`, between
  `<!-- codegen:clients:start -->` / `<!-- codegen:clients:end -->`
  markers. Replaces the manually-maintained list that was kept in sync
  by a `pbcopy` one-liner in an HTML comment.
- Detect deprecation per client from the OpenAPI spec: if any operation
  has `deprecated: true`, suffix the bullet with "— contains deprecated
  operations" and render a note at the top of the generated client
  README from the template.
- Only `orders-api-v0` matches today (6/10 ops deprecated in `ordersV0`).
  When Amazon marks more operations deprecated in future model updates,
  the codegen PR will pick them up automatically.

## Test plan

- [x] `pnpm --filter @sp-api-sdk/generator check:ts`
- [x] `pnpm --filter @sp-api-sdk/generator xo`
- [x] Verify next scheduled codegen run produces no unexpected diff
      beyond the `orders-api-v0` deprecation note