### PR TITLE
docs: simplify auth samples in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ npm install @sp-api-sdk/auth @sp-api-sdk/orders-api-2026-01-01
 import { SellingPartnerApiAuth } from "@sp-api-sdk/auth";
 import { OrdersApiClient } from "@sp-api-sdk/orders-api-2026-01-01";
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: "Atzr|…",
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 });
 
 const client = new OrdersApiClient({

--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/README.md
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/amazon-warehousing-and-distribution-api-2024-05-09
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {AmazonWarehousingAndDistributionApiClient} from '@sp-api-sdk/amazon-warehousing-and-distribution-api-2024-05-09'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new AmazonWarehousingAndDistributionApiClient({

--- a/clients/aplus-content-api-2020-11-01/README.md
+++ b/clients/aplus-content-api-2020-11-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/aplus-content-api-2020-11-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {AplusContentApiClient} from '@sp-api-sdk/aplus-content-api-2020-11-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new AplusContentApiClient({

--- a/clients/application-integrations-api-2024-04-01/README.md
+++ b/clients/application-integrations-api-2024-04-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/application-integrations-api-2024-04-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ApplicationIntegrationsApiClient} from '@sp-api-sdk/application-integrations-api-2024-04-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ApplicationIntegrationsApiClient({

--- a/clients/application-management-api-2023-11-30/README.md
+++ b/clients/application-management-api-2023-11-30/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/application-management-api-2023-11-30
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ApplicationManagementApiClient} from '@sp-api-sdk/application-management-api-2023-11-30'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ApplicationManagementApiClient({

--- a/clients/catalog-items-api-2020-12-01/README.md
+++ b/clients/catalog-items-api-2020-12-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/catalog-items-api-2020-12-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {CatalogItemsApiClient} from '@sp-api-sdk/catalog-items-api-2020-12-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new CatalogItemsApiClient({

--- a/clients/catalog-items-api-2022-04-01/README.md
+++ b/clients/catalog-items-api-2022-04-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/catalog-items-api-2022-04-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {CatalogItemsApiClient} from '@sp-api-sdk/catalog-items-api-2022-04-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new CatalogItemsApiClient({

--- a/clients/catalog-items-api-v0/README.md
+++ b/clients/catalog-items-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/catalog-items-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {CatalogItemsApiClient} from '@sp-api-sdk/catalog-items-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new CatalogItemsApiClient({

--- a/clients/customer-feedback-api-2024-06-01/README.md
+++ b/clients/customer-feedback-api-2024-06-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/customer-feedback-api-2024-06-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {CustomerFeedbackApiClient} from '@sp-api-sdk/customer-feedback-api-2024-06-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new CustomerFeedbackApiClient({

--- a/clients/data-kiosk-api-2023-11-15/README.md
+++ b/clients/data-kiosk-api-2023-11-15/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/data-kiosk-api-2023-11-15
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {DataKioskApiClient} from '@sp-api-sdk/data-kiosk-api-2023-11-15'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new DataKioskApiClient({

--- a/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/README.md
+++ b/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {DeliveryByAmazonDeliveryShipmentInvoiceV20220701ApiClient} from '@sp-api-sdk/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new DeliveryByAmazonDeliveryShipmentInvoiceV20220701ApiClient({

--- a/clients/easy-ship-api-2022-03-23/README.md
+++ b/clients/easy-ship-api-2022-03-23/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/easy-ship-api-2022-03-23
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {EasyShipApiClient} from '@sp-api-sdk/easy-ship-api-2022-03-23'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new EasyShipApiClient({

--- a/clients/external-fulfillment-inventory-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-inventory-api-2024-09-11/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/external-fulfillment-inventory-api-2024-09-11
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ExternalFulfillmentInventoryApiClient} from '@sp-api-sdk/external-fulfillment-inventory-api-2024-09-11'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ExternalFulfillmentInventoryApiClient({

--- a/clients/external-fulfillment-returns-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-returns-api-2024-09-11/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/external-fulfillment-returns-api-2024-09-11
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ExternalFulfillmentReturnsApiClient} from '@sp-api-sdk/external-fulfillment-returns-api-2024-09-11'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ExternalFulfillmentReturnsApiClient({

--- a/clients/external-fulfillment-shipments-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/external-fulfillment-shipments-api-2024-09-11
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ExternalFulfillmentShipmentsApiClient} from '@sp-api-sdk/external-fulfillment-shipments-api-2024-09-11'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ExternalFulfillmentShipmentsApiClient({

--- a/clients/fba-inbound-eligibility-api-v1/README.md
+++ b/clients/fba-inbound-eligibility-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/fba-inbound-eligibility-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FbaInboundEligibilityApiClient} from '@sp-api-sdk/fba-inbound-eligibility-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FbaInboundEligibilityApiClient({

--- a/clients/fba-inventory-api-v1/README.md
+++ b/clients/fba-inventory-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/fba-inventory-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FbaInventoryApiClient} from '@sp-api-sdk/fba-inventory-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FbaInventoryApiClient({

--- a/clients/feeds-api-2021-06-30/README.md
+++ b/clients/feeds-api-2021-06-30/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/feeds-api-2021-06-30
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FeedsApiClient} from '@sp-api-sdk/feeds-api-2021-06-30'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FeedsApiClient({

--- a/clients/finances-api-2024-06-19/README.md
+++ b/clients/finances-api-2024-06-19/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/finances-api-2024-06-19
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FinancesApiClient} from '@sp-api-sdk/finances-api-2024-06-19'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FinancesApiClient({

--- a/clients/finances-api-v0/README.md
+++ b/clients/finances-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/finances-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FinancesApiClient} from '@sp-api-sdk/finances-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FinancesApiClient({

--- a/clients/finances-transfers-api-2024-06-01/README.md
+++ b/clients/finances-transfers-api-2024-06-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/finances-transfers-api-2024-06-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FinancesTransfersApiClient} from '@sp-api-sdk/finances-transfers-api-2024-06-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FinancesTransfersApiClient({

--- a/clients/fulfillment-inbound-api-2024-03-20/README.md
+++ b/clients/fulfillment-inbound-api-2024-03-20/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/fulfillment-inbound-api-2024-03-20
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FulfillmentInboundApiClient} from '@sp-api-sdk/fulfillment-inbound-api-2024-03-20'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FulfillmentInboundApiClient({

--- a/clients/fulfillment-inbound-api-v0/README.md
+++ b/clients/fulfillment-inbound-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/fulfillment-inbound-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FulfillmentInboundApiClient} from '@sp-api-sdk/fulfillment-inbound-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FulfillmentInboundApiClient({

--- a/clients/fulfillment-outbound-api-2020-07-01/README.md
+++ b/clients/fulfillment-outbound-api-2020-07-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/fulfillment-outbound-api-2020-07-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {FulfillmentOutboundApiClient} from '@sp-api-sdk/fulfillment-outbound-api-2020-07-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new FulfillmentOutboundApiClient({

--- a/clients/invoices-api-2024-06-19/README.md
+++ b/clients/invoices-api-2024-06-19/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/invoices-api-2024-06-19
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {InvoicesApiClient} from '@sp-api-sdk/invoices-api-2024-06-19'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new InvoicesApiClient({

--- a/clients/listings-items-api-2020-09-01/README.md
+++ b/clients/listings-items-api-2020-09-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/listings-items-api-2020-09-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ListingsItemsApiClient} from '@sp-api-sdk/listings-items-api-2020-09-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ListingsItemsApiClient({

--- a/clients/listings-items-api-2021-08-01/README.md
+++ b/clients/listings-items-api-2021-08-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/listings-items-api-2021-08-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ListingsItemsApiClient} from '@sp-api-sdk/listings-items-api-2021-08-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ListingsItemsApiClient({

--- a/clients/listings-restrictions-api-2021-08-01/README.md
+++ b/clients/listings-restrictions-api-2021-08-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/listings-restrictions-api-2021-08-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ListingsRestrictionsApiClient} from '@sp-api-sdk/listings-restrictions-api-2021-08-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ListingsRestrictionsApiClient({

--- a/clients/merchant-fulfillment-api-v0/README.md
+++ b/clients/merchant-fulfillment-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/merchant-fulfillment-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {MerchantFulfillmentApiClient} from '@sp-api-sdk/merchant-fulfillment-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new MerchantFulfillmentApiClient({

--- a/clients/messaging-api-v1/README.md
+++ b/clients/messaging-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/messaging-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {MessagingApiClient} from '@sp-api-sdk/messaging-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new MessagingApiClient({

--- a/clients/notifications-api-v1/README.md
+++ b/clients/notifications-api-v1/README.md
@@ -29,16 +29,15 @@ npm install @sp-api-sdk/notifications-api-v1
 import {SellingPartnerApiAuth, AuthorizationScope} from '@sp-api-sdk/auth'
 import {NotificationsApiClient} from '@sp-api-sdk/notifications-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
   scopes: [AuthorizationScope.NOTIFICATIONS],
 })
 
-
 const client = new NotificationsApiClient({
   auth,
-  region: 'eu'
+  region: 'eu',
 })
 ```
 
@@ -48,10 +47,10 @@ const client = new NotificationsApiClient({
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {NotificationsApiClient} from '@sp-api-sdk/notifications-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new NotificationsApiClient({

--- a/clients/orders-api-2026-01-01/README.md
+++ b/clients/orders-api-2026-01-01/README.md
@@ -31,10 +31,10 @@ npm install @sp-api-sdk/orders-api-2026-01-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {OrdersApiClient} from '@sp-api-sdk/orders-api-2026-01-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new OrdersApiClient({

--- a/clients/orders-api-v0/README.md
+++ b/clients/orders-api-v0/README.md
@@ -29,10 +29,10 @@ npm install @sp-api-sdk/orders-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {OrdersApiClient} from '@sp-api-sdk/orders-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new OrdersApiClient({

--- a/clients/product-fees-api-v0/README.md
+++ b/clients/product-fees-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/product-fees-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ProductFeesApiClient} from '@sp-api-sdk/product-fees-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ProductFeesApiClient({

--- a/clients/product-pricing-api-2022-05-01/README.md
+++ b/clients/product-pricing-api-2022-05-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/product-pricing-api-2022-05-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ProductPricingApiClient} from '@sp-api-sdk/product-pricing-api-2022-05-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ProductPricingApiClient({

--- a/clients/product-pricing-api-v0/README.md
+++ b/clients/product-pricing-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/product-pricing-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ProductPricingApiClient} from '@sp-api-sdk/product-pricing-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ProductPricingApiClient({

--- a/clients/product-type-definitions-api-2020-09-01/README.md
+++ b/clients/product-type-definitions-api-2020-09-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/product-type-definitions-api-2020-09-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ProductTypeDefinitionsApiClient} from '@sp-api-sdk/product-type-definitions-api-2020-09-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ProductTypeDefinitionsApiClient({

--- a/clients/replenishment-api-2022-11-07/README.md
+++ b/clients/replenishment-api-2022-11-07/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/replenishment-api-2022-11-07
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ReplenishmentApiClient} from '@sp-api-sdk/replenishment-api-2022-11-07'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ReplenishmentApiClient({

--- a/clients/reports-api-2021-06-30/README.md
+++ b/clients/reports-api-2021-06-30/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/reports-api-2021-06-30
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ReportsApiClient} from '@sp-api-sdk/reports-api-2021-06-30'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ReportsApiClient({

--- a/clients/sales-api-v1/README.md
+++ b/clients/sales-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/sales-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {SalesApiClient} from '@sp-api-sdk/sales-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new SalesApiClient({

--- a/clients/seller-wallet-api-2024-03-01/README.md
+++ b/clients/seller-wallet-api-2024-03-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/seller-wallet-api-2024-03-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {SellerWalletApiClient} from '@sp-api-sdk/seller-wallet-api-2024-03-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new SellerWalletApiClient({

--- a/clients/sellers-api-v1/README.md
+++ b/clients/sellers-api-v1/README.md
@@ -31,10 +31,10 @@ npm install @sp-api-sdk/sellers-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {SellersApiClient} from '@sp-api-sdk/sellers-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new SellersApiClient({

--- a/clients/services-api-v1/README.md
+++ b/clients/services-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/services-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ServicesApiClient} from '@sp-api-sdk/services-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ServicesApiClient({

--- a/clients/shipment-invoicing-api-v0/README.md
+++ b/clients/shipment-invoicing-api-v0/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/shipment-invoicing-api-v0
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ShipmentInvoicingApiClient} from '@sp-api-sdk/shipment-invoicing-api-v0'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ShipmentInvoicingApiClient({

--- a/clients/shipping-api-v1/README.md
+++ b/clients/shipping-api-v1/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/shipping-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ShippingApiClient} from '@sp-api-sdk/shipping-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ShippingApiClient({

--- a/clients/shipping-api-v2/README.md
+++ b/clients/shipping-api-v2/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/shipping-api-v2
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {ShippingApiClient} from '@sp-api-sdk/shipping-api-v2'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new ShippingApiClient({

--- a/clients/solicitations-api-v1/README.md
+++ b/clients/solicitations-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/solicitations-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {SolicitationsApiClient} from '@sp-api-sdk/solicitations-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new SolicitationsApiClient({

--- a/clients/supply-sources-api-2020-07-01/README.md
+++ b/clients/supply-sources-api-2020-07-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/supply-sources-api-2020-07-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {SupplySourcesApiClient} from '@sp-api-sdk/supply-sources-api-2020-07-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new SupplySourcesApiClient({

--- a/clients/tokens-api-2021-03-01/README.md
+++ b/clients/tokens-api-2021-03-01/README.md
@@ -27,10 +27,10 @@ npm install @sp-api-sdk/tokens-api-2021-03-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {TokensApiClient} from '@sp-api-sdk/tokens-api-2021-03-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new TokensApiClient({

--- a/clients/uploads-api-2020-11-01/README.md
+++ b/clients/uploads-api-2020-11-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/uploads-api-2020-11-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {UploadsApiClient} from '@sp-api-sdk/uploads-api-2020-11-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new UploadsApiClient({

--- a/clients/vehicles-api-2024-11-01/README.md
+++ b/clients/vehicles-api-2024-11-01/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vehicles-api-2024-11-01
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VehiclesApiClient} from '@sp-api-sdk/vehicles-api-2024-11-01'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VehiclesApiClient({

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-inventory-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentInventoryApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-inventory-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentInventoryApiClient({

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-orders-api-2021-12-28
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentOrdersApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-orders-api-2021-12-28'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentOrdersApiClient({

--- a/clients/vendor-direct-fulfillment-orders-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-orders-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentOrdersApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-orders-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentOrdersApiClient({

--- a/clients/vendor-direct-fulfillment-payments-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-payments-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentPaymentsApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-payments-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentPaymentsApiClient({

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentSandboxTestDataApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentSandboxTestDataApiClient({

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-shipping-api-2021-12-28
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentShippingApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-shipping-api-2021-12-28'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentShippingApiClient({

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-shipping-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentShippingApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-shipping-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentShippingApiClient({

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-transactions-api-2021-12-28
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentTransactionsApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-transactions-api-2021-12-28'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentTransactionsApiClient({

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-direct-fulfillment-transactions-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorDirectFulfillmentTransactionsApiClient} from '@sp-api-sdk/vendor-direct-fulfillment-transactions-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorDirectFulfillmentTransactionsApiClient({

--- a/clients/vendor-invoices-api-v1/README.md
+++ b/clients/vendor-invoices-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-invoices-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorInvoicesApiClient} from '@sp-api-sdk/vendor-invoices-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorInvoicesApiClient({

--- a/clients/vendor-orders-api-v1/README.md
+++ b/clients/vendor-orders-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-orders-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorOrdersApiClient} from '@sp-api-sdk/vendor-orders-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorOrdersApiClient({

--- a/clients/vendor-shipments-api-v1/README.md
+++ b/clients/vendor-shipments-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-shipments-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorShipmentsApiClient} from '@sp-api-sdk/vendor-shipments-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorShipmentsApiClient({

--- a/clients/vendor-transaction-status-api-v1/README.md
+++ b/clients/vendor-transaction-status-api-v1/README.md
@@ -25,10 +25,10 @@ npm install @sp-api-sdk/vendor-transaction-status-api-v1
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {VendorTransactionStatusApiClient} from '@sp-api-sdk/vendor-transaction-status-api-v1'
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new VendorTransactionStatusApiClient({

--- a/codegen/templates/README.md.mustache
+++ b/codegen/templates/README.md.mustache
@@ -34,16 +34,15 @@ import {SellingPartnerApiAuth, AuthorizationScope} from '@sp-api-sdk/auth'
 import {<%className%>} from '@sp-api-sdk/<%packageName%>'
 <%={{ }}=%>
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
   scopes: [AuthorizationScope.{{grantlessScope}}],
 })
 
-
 const client = new {{className}}({
   auth,
-  region: 'eu'
+  region: 'eu',
 })
 ```
 
@@ -56,10 +55,10 @@ import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {<%className%>} from '@sp-api-sdk/<%packageName%>'
 <%={{ }}=%>
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: 'Atzr|…',
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 })
 
 const client = new {{className}}({

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -20,10 +20,10 @@ The `SellingPartnerApiAuth` class handles OAuth token acquisition from Login wit
 ```javascript
 import { SellingPartnerApiAuth } from "@sp-api-sdk/auth";
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
-  refreshToken: "Atzr|…",
+  refreshToken: await getRefreshTokenForSeller(sellerId),
 });
 
 const accessToken = await auth.getAccessToken();
@@ -31,7 +31,7 @@ const accessToken = await auth.getAccessToken();
 
 ## Default values from the environment
 
-These constructor options can be passed using environment variables:
+The following constructor options default to environment variables when omitted. You can still pass them explicitly to override the defaults.
 
 | Property Name  | Environment variable |
 | -------------- | -------------------- |
@@ -48,9 +48,9 @@ The available scopes are exposed in the `AuthorizationScope` enum from this libr
 import { SellingPartnerApiAuth, AuthorizationScope } from "@sp-api-sdk/auth";
 import { NotificationsApiClient } from "@sp-api-sdk/notifications-api-v1";
 
+// `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
+// `LWA_CLIENT_SECRET` environment variables.
 const auth = new SellingPartnerApiAuth({
-  clientId: process.env.LWA_CLIENT_ID,
-  clientSecret: process.env.LWA_CLIENT_SECRET,
   scopes: [AuthorizationScope.NOTIFICATIONS],
 });
 


### PR DESCRIPTION
## Summary

- Drop the redundant `clientId`/`clientSecret` lines from the auth samples — the auth package already defaults them to `LWA_CLIENT_ID` / `LWA_CLIENT_SECRET` env vars, so re-passing them in every snippet was misleading.
- Replace the hardcoded `refreshToken: 'Atzr|…'` placeholder with `await getRefreshTokenForSeller(sellerId)` to model the realistic multi-tenant case where refresh tokens are resolved dynamically per seller.
- Tighten the "Default values from the environment" intro in [`@sp-api-sdk/auth`](packages/auth/README.md) so it's explicit that the env-var defaults can still be overridden by passing the options.

Changes are in the Mustache template and the two hand-written READMEs; all 63 generated client READMEs were regenerated via `pnpm codegen clients` and are included.

## Test plan

- [x] Browse a few generated client READMEs (e.g. `clients/orders-api-2026-01-01/README.md`, `clients/notifications-api-v1/README.md`) and confirm the snippets read sensibly.
- [x] Confirm only README files changed (no model or client code drift).