### PR TITLE
fix(codegen): move openapi-types to dependencies

### DIFF
--- a/codegen/package.json
+++ b/codegen/package.json
@@ -19,6 +19,7 @@
     "jsonfile": "^6.2.1",
     "lodash-es": "^4.18.1",
     "mustache": "^4.2.0",
+    "openapi-types": "^12.1.3",
     "p-map": "^7.0.4",
     "remark": "^15.0.1",
     "strip-markdown": "^6.0.0",
@@ -29,7 +30,6 @@
     "@types/jsonfile": "^6.1.4",
     "@types/lodash-es": "^4.17.12",
     "@types/mustache": "^4.2.6",
-    "openapi-types": "^12.1.3",
     "type-fest": "^5.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,6 +905,9 @@ importers:
       mustache:
         specifier: ^4.2.0
         version: 4.2.0
+      openapi-types:
+        specifier: ^12.1.3
+        version: 12.1.3
       p-map:
         specifier: ^7.0.4
         version: 7.0.4
@@ -930,9 +933,6 @@ importers:
       '@types/mustache':
         specifier: ^4.2.6
         version: 4.2.6
-      openapi-types:
-        specifier: ^12.1.3
-        version: 12.1.3
       type-fest:
         specifier: ^5.6.0
         version: 5.6.0


### PR DESCRIPTION
## Summary

- Since #1775, [generate-clients.ts:42](codegen/generate-clients.ts#L42) uses `OpenAPIV3.HttpMethods` as a runtime value (enum), not a type.
- Move `openapi-types` from `devDependencies` to `dependencies` in [codegen/package.json](codegen/package.json) so the import resolves when running `pnpm codegen`.

## Test plan

- [x] `pnpm --filter @sp-api-sdk/generator check:ts` passes