### PR TITLE
docs(codegen): prefix client README titles with @sp-api-sdk/

### DIFF
--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/README.md
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/README.md
@@ -1,4 +1,4 @@
-# `amazon-warehousing-and-distribution-api-2024-05-09`
+# `@sp-api-sdk/amazon-warehousing-and-distribution-api-2024-05-09`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/amazon-warehousing-and-distribution-api-2024-05-09)](https://www.npmjs.com/package/@sp-api-sdk/amazon-warehousing-and-distribution-api-2024-05-09)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/aplus-content-api-2020-11-01/README.md
+++ b/clients/aplus-content-api-2020-11-01/README.md
@@ -1,4 +1,4 @@
-# `aplus-content-api-2020-11-01`
+# `@sp-api-sdk/aplus-content-api-2020-11-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/aplus-content-api-2020-11-01)](https://www.npmjs.com/package/@sp-api-sdk/aplus-content-api-2020-11-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/application-integrations-api-2024-04-01/README.md
+++ b/clients/application-integrations-api-2024-04-01/README.md
@@ -1,4 +1,4 @@
-# `application-integrations-api-2024-04-01`
+# `@sp-api-sdk/application-integrations-api-2024-04-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/application-integrations-api-2024-04-01)](https://www.npmjs.com/package/@sp-api-sdk/application-integrations-api-2024-04-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/application-management-api-2023-11-30/README.md
+++ b/clients/application-management-api-2023-11-30/README.md
@@ -1,4 +1,4 @@
-# `application-management-api-2023-11-30`
+# `@sp-api-sdk/application-management-api-2023-11-30`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/application-management-api-2023-11-30)](https://www.npmjs.com/package/@sp-api-sdk/application-management-api-2023-11-30)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/catalog-items-api-2020-12-01/README.md
+++ b/clients/catalog-items-api-2020-12-01/README.md
@@ -1,4 +1,4 @@
-# `catalog-items-api-2020-12-01`
+# `@sp-api-sdk/catalog-items-api-2020-12-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/catalog-items-api-2020-12-01)](https://www.npmjs.com/package/@sp-api-sdk/catalog-items-api-2020-12-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/catalog-items-api-2022-04-01/README.md
+++ b/clients/catalog-items-api-2022-04-01/README.md
@@ -1,4 +1,4 @@
-# `catalog-items-api-2022-04-01`
+# `@sp-api-sdk/catalog-items-api-2022-04-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/catalog-items-api-2022-04-01)](https://www.npmjs.com/package/@sp-api-sdk/catalog-items-api-2022-04-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/catalog-items-api-v0/README.md
+++ b/clients/catalog-items-api-v0/README.md
@@ -1,4 +1,4 @@
-# `catalog-items-api-v0`
+# `@sp-api-sdk/catalog-items-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/catalog-items-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/catalog-items-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/customer-feedback-api-2024-06-01/README.md
+++ b/clients/customer-feedback-api-2024-06-01/README.md
@@ -1,4 +1,4 @@
-# `customer-feedback-api-2024-06-01`
+# `@sp-api-sdk/customer-feedback-api-2024-06-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/customer-feedback-api-2024-06-01)](https://www.npmjs.com/package/@sp-api-sdk/customer-feedback-api-2024-06-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/data-kiosk-api-2023-11-15/README.md
+++ b/clients/data-kiosk-api-2023-11-15/README.md
@@ -1,4 +1,4 @@
-# `data-kiosk-api-2023-11-15`
+# `@sp-api-sdk/data-kiosk-api-2023-11-15`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/data-kiosk-api-2023-11-15)](https://www.npmjs.com/package/@sp-api-sdk/data-kiosk-api-2023-11-15)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/README.md
+++ b/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/README.md
@@ -1,4 +1,4 @@
-# `delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01`
+# `@sp-api-sdk/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01)](https://www.npmjs.com/package/@sp-api-sdk/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/easy-ship-api-2022-03-23/README.md
+++ b/clients/easy-ship-api-2022-03-23/README.md
@@ -1,4 +1,4 @@
-# `easy-ship-api-2022-03-23`
+# `@sp-api-sdk/easy-ship-api-2022-03-23`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/easy-ship-api-2022-03-23)](https://www.npmjs.com/package/@sp-api-sdk/easy-ship-api-2022-03-23)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/external-fulfillment-inventory-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-inventory-api-2024-09-11/README.md
@@ -1,4 +1,4 @@
-# `external-fulfillment-inventory-api-2024-09-11`
+# `@sp-api-sdk/external-fulfillment-inventory-api-2024-09-11`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/external-fulfillment-inventory-api-2024-09-11)](https://www.npmjs.com/package/@sp-api-sdk/external-fulfillment-inventory-api-2024-09-11)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/external-fulfillment-returns-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-returns-api-2024-09-11/README.md
@@ -1,4 +1,4 @@
-# `external-fulfillment-returns-api-2024-09-11`
+# `@sp-api-sdk/external-fulfillment-returns-api-2024-09-11`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/external-fulfillment-returns-api-2024-09-11)](https://www.npmjs.com/package/@sp-api-sdk/external-fulfillment-returns-api-2024-09-11)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/external-fulfillment-shipments-api-2024-09-11/README.md
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/README.md
@@ -1,4 +1,4 @@
-# `external-fulfillment-shipments-api-2024-09-11`
+# `@sp-api-sdk/external-fulfillment-shipments-api-2024-09-11`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/external-fulfillment-shipments-api-2024-09-11)](https://www.npmjs.com/package/@sp-api-sdk/external-fulfillment-shipments-api-2024-09-11)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/fba-inbound-eligibility-api-v1/README.md
+++ b/clients/fba-inbound-eligibility-api-v1/README.md
@@ -1,4 +1,4 @@
-# `fba-inbound-eligibility-api-v1`
+# `@sp-api-sdk/fba-inbound-eligibility-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fba-inbound-eligibility-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/fba-inbound-eligibility-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/fba-inventory-api-v1/README.md
+++ b/clients/fba-inventory-api-v1/README.md
@@ -1,4 +1,4 @@
-# `fba-inventory-api-v1`
+# `@sp-api-sdk/fba-inventory-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fba-inventory-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/fba-inventory-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/feeds-api-2021-06-30/README.md
+++ b/clients/feeds-api-2021-06-30/README.md
@@ -1,4 +1,4 @@
-# `feeds-api-2021-06-30`
+# `@sp-api-sdk/feeds-api-2021-06-30`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/feeds-api-2021-06-30)](https://www.npmjs.com/package/@sp-api-sdk/feeds-api-2021-06-30)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/finances-api-2024-06-19/README.md
+++ b/clients/finances-api-2024-06-19/README.md
@@ -1,4 +1,4 @@
-# `finances-api-2024-06-19`
+# `@sp-api-sdk/finances-api-2024-06-19`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/finances-api-2024-06-19)](https://www.npmjs.com/package/@sp-api-sdk/finances-api-2024-06-19)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/finances-api-v0/README.md
+++ b/clients/finances-api-v0/README.md
@@ -1,4 +1,4 @@
-# `finances-api-v0`
+# `@sp-api-sdk/finances-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/finances-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/finances-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/finances-transfers-api-2024-06-01/README.md
+++ b/clients/finances-transfers-api-2024-06-01/README.md
@@ -1,4 +1,4 @@
-# `finances-transfers-api-2024-06-01`
+# `@sp-api-sdk/finances-transfers-api-2024-06-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/finances-transfers-api-2024-06-01)](https://www.npmjs.com/package/@sp-api-sdk/finances-transfers-api-2024-06-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/fulfillment-inbound-api-2024-03-20/README.md
+++ b/clients/fulfillment-inbound-api-2024-03-20/README.md
@@ -1,4 +1,4 @@
-# `fulfillment-inbound-api-2024-03-20`
+# `@sp-api-sdk/fulfillment-inbound-api-2024-03-20`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fulfillment-inbound-api-2024-03-20)](https://www.npmjs.com/package/@sp-api-sdk/fulfillment-inbound-api-2024-03-20)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/fulfillment-inbound-api-v0/README.md
+++ b/clients/fulfillment-inbound-api-v0/README.md
@@ -1,4 +1,4 @@
-# `fulfillment-inbound-api-v0`
+# `@sp-api-sdk/fulfillment-inbound-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fulfillment-inbound-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/fulfillment-inbound-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/fulfillment-outbound-api-2020-07-01/README.md
+++ b/clients/fulfillment-outbound-api-2020-07-01/README.md
@@ -1,4 +1,4 @@
-# `fulfillment-outbound-api-2020-07-01`
+# `@sp-api-sdk/fulfillment-outbound-api-2020-07-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fulfillment-outbound-api-2020-07-01)](https://www.npmjs.com/package/@sp-api-sdk/fulfillment-outbound-api-2020-07-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/invoices-api-2024-06-19/README.md
+++ b/clients/invoices-api-2024-06-19/README.md
@@ -1,4 +1,4 @@
-# `invoices-api-2024-06-19`
+# `@sp-api-sdk/invoices-api-2024-06-19`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/invoices-api-2024-06-19)](https://www.npmjs.com/package/@sp-api-sdk/invoices-api-2024-06-19)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/listings-items-api-2020-09-01/README.md
+++ b/clients/listings-items-api-2020-09-01/README.md
@@ -1,4 +1,4 @@
-# `listings-items-api-2020-09-01`
+# `@sp-api-sdk/listings-items-api-2020-09-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/listings-items-api-2020-09-01)](https://www.npmjs.com/package/@sp-api-sdk/listings-items-api-2020-09-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/listings-items-api-2021-08-01/README.md
+++ b/clients/listings-items-api-2021-08-01/README.md
@@ -1,4 +1,4 @@
-# `listings-items-api-2021-08-01`
+# `@sp-api-sdk/listings-items-api-2021-08-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/listings-items-api-2021-08-01)](https://www.npmjs.com/package/@sp-api-sdk/listings-items-api-2021-08-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/listings-restrictions-api-2021-08-01/README.md
+++ b/clients/listings-restrictions-api-2021-08-01/README.md
@@ -1,4 +1,4 @@
-# `listings-restrictions-api-2021-08-01`
+# `@sp-api-sdk/listings-restrictions-api-2021-08-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/listings-restrictions-api-2021-08-01)](https://www.npmjs.com/package/@sp-api-sdk/listings-restrictions-api-2021-08-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/merchant-fulfillment-api-v0/README.md
+++ b/clients/merchant-fulfillment-api-v0/README.md
@@ -1,4 +1,4 @@
-# `merchant-fulfillment-api-v0`
+# `@sp-api-sdk/merchant-fulfillment-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/merchant-fulfillment-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/merchant-fulfillment-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/messaging-api-v1/README.md
+++ b/clients/messaging-api-v1/README.md
@@ -1,4 +1,4 @@
-# `messaging-api-v1`
+# `@sp-api-sdk/messaging-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/messaging-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/messaging-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/notifications-api-v1/README.md
+++ b/clients/notifications-api-v1/README.md
@@ -1,4 +1,4 @@
-# `notifications-api-v1`
+# `@sp-api-sdk/notifications-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/notifications-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/notifications-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/orders-api-2026-01-01/README.md
+++ b/clients/orders-api-2026-01-01/README.md
@@ -1,4 +1,4 @@
-# `orders-api-2026-01-01`
+# `@sp-api-sdk/orders-api-2026-01-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/orders-api-2026-01-01)](https://www.npmjs.com/package/@sp-api-sdk/orders-api-2026-01-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/orders-api-v0/README.md
+++ b/clients/orders-api-v0/README.md
@@ -1,4 +1,4 @@
-# `orders-api-v0`
+# `@sp-api-sdk/orders-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/orders-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/orders-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/product-fees-api-v0/README.md
+++ b/clients/product-fees-api-v0/README.md
@@ -1,4 +1,4 @@
-# `product-fees-api-v0`
+# `@sp-api-sdk/product-fees-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/product-fees-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/product-fees-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/product-pricing-api-2022-05-01/README.md
+++ b/clients/product-pricing-api-2022-05-01/README.md
@@ -1,4 +1,4 @@
-# `product-pricing-api-2022-05-01`
+# `@sp-api-sdk/product-pricing-api-2022-05-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/product-pricing-api-2022-05-01)](https://www.npmjs.com/package/@sp-api-sdk/product-pricing-api-2022-05-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/product-pricing-api-v0/README.md
+++ b/clients/product-pricing-api-v0/README.md
@@ -1,4 +1,4 @@
-# `product-pricing-api-v0`
+# `@sp-api-sdk/product-pricing-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/product-pricing-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/product-pricing-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/product-type-definitions-api-2020-09-01/README.md
+++ b/clients/product-type-definitions-api-2020-09-01/README.md
@@ -1,4 +1,4 @@
-# `product-type-definitions-api-2020-09-01`
+# `@sp-api-sdk/product-type-definitions-api-2020-09-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/product-type-definitions-api-2020-09-01)](https://www.npmjs.com/package/@sp-api-sdk/product-type-definitions-api-2020-09-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/replenishment-api-2022-11-07/README.md
+++ b/clients/replenishment-api-2022-11-07/README.md
@@ -1,4 +1,4 @@
-# `replenishment-api-2022-11-07`
+# `@sp-api-sdk/replenishment-api-2022-11-07`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/replenishment-api-2022-11-07)](https://www.npmjs.com/package/@sp-api-sdk/replenishment-api-2022-11-07)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/reports-api-2021-06-30/README.md
+++ b/clients/reports-api-2021-06-30/README.md
@@ -1,4 +1,4 @@
-# `reports-api-2021-06-30`
+# `@sp-api-sdk/reports-api-2021-06-30`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/reports-api-2021-06-30)](https://www.npmjs.com/package/@sp-api-sdk/reports-api-2021-06-30)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/sales-api-v1/README.md
+++ b/clients/sales-api-v1/README.md
@@ -1,4 +1,4 @@
-# `sales-api-v1`
+# `@sp-api-sdk/sales-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/sales-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/sales-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/seller-wallet-api-2024-03-01/README.md
+++ b/clients/seller-wallet-api-2024-03-01/README.md
@@ -1,4 +1,4 @@
-# `seller-wallet-api-2024-03-01`
+# `@sp-api-sdk/seller-wallet-api-2024-03-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/seller-wallet-api-2024-03-01)](https://www.npmjs.com/package/@sp-api-sdk/seller-wallet-api-2024-03-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/sellers-api-v1/README.md
+++ b/clients/sellers-api-v1/README.md
@@ -1,4 +1,4 @@
-# `sellers-api-v1`
+# `@sp-api-sdk/sellers-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/sellers-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/sellers-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/services-api-v1/README.md
+++ b/clients/services-api-v1/README.md
@@ -1,4 +1,4 @@
-# `services-api-v1`
+# `@sp-api-sdk/services-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/services-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/services-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/shipment-invoicing-api-v0/README.md
+++ b/clients/shipment-invoicing-api-v0/README.md
@@ -1,4 +1,4 @@
-# `shipment-invoicing-api-v0`
+# `@sp-api-sdk/shipment-invoicing-api-v0`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/shipment-invoicing-api-v0)](https://www.npmjs.com/package/@sp-api-sdk/shipment-invoicing-api-v0)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/shipping-api-v1/README.md
+++ b/clients/shipping-api-v1/README.md
@@ -1,4 +1,4 @@
-# `shipping-api-v1`
+# `@sp-api-sdk/shipping-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/shipping-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/shipping-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/shipping-api-v2/README.md
+++ b/clients/shipping-api-v2/README.md
@@ -1,4 +1,4 @@
-# `shipping-api-v2`
+# `@sp-api-sdk/shipping-api-v2`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/shipping-api-v2)](https://www.npmjs.com/package/@sp-api-sdk/shipping-api-v2)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/solicitations-api-v1/README.md
+++ b/clients/solicitations-api-v1/README.md
@@ -1,4 +1,4 @@
-# `solicitations-api-v1`
+# `@sp-api-sdk/solicitations-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/solicitations-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/solicitations-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/supply-sources-api-2020-07-01/README.md
+++ b/clients/supply-sources-api-2020-07-01/README.md
@@ -1,4 +1,4 @@
-# `supply-sources-api-2020-07-01`
+# `@sp-api-sdk/supply-sources-api-2020-07-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/supply-sources-api-2020-07-01)](https://www.npmjs.com/package/@sp-api-sdk/supply-sources-api-2020-07-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/tokens-api-2021-03-01/README.md
+++ b/clients/tokens-api-2021-03-01/README.md
@@ -1,4 +1,4 @@
-# `tokens-api-2021-03-01`
+# `@sp-api-sdk/tokens-api-2021-03-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/tokens-api-2021-03-01)](https://www.npmjs.com/package/@sp-api-sdk/tokens-api-2021-03-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/uploads-api-2020-11-01/README.md
+++ b/clients/uploads-api-2020-11-01/README.md
@@ -1,4 +1,4 @@
-# `uploads-api-2020-11-01`
+# `@sp-api-sdk/uploads-api-2020-11-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/uploads-api-2020-11-01)](https://www.npmjs.com/package/@sp-api-sdk/uploads-api-2020-11-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vehicles-api-2024-11-01/README.md
+++ b/clients/vehicles-api-2024-11-01/README.md
@@ -1,4 +1,4 @@
-# `vehicles-api-2024-11-01`
+# `@sp-api-sdk/vehicles-api-2024-11-01`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vehicles-api-2024-11-01)](https://www.npmjs.com/package/@sp-api-sdk/vehicles-api-2024-11-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-inventory-api-v1`
+# `@sp-api-sdk/vendor-direct-fulfillment-inventory-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-inventory-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-inventory-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-orders-api-2021-12-28`
+# `@sp-api-sdk/vendor-direct-fulfillment-orders-api-2021-12-28`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-orders-api-2021-12-28)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-orders-api-2021-12-28)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-orders-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-orders-api-v1`
+# `@sp-api-sdk/vendor-direct-fulfillment-orders-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-orders-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-orders-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-payments-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-payments-api-v1`
+# `@sp-api-sdk/vendor-direct-fulfillment-payments-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-payments-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-payments-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28`
+# `@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-shipping-api-2021-12-28`
+# `@sp-api-sdk/vendor-direct-fulfillment-shipping-api-2021-12-28`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-shipping-api-2021-12-28)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-shipping-api-2021-12-28)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-shipping-api-v1`
+# `@sp-api-sdk/vendor-direct-fulfillment-shipping-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-shipping-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-shipping-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/README.md
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-transactions-api-2021-12-28`
+# `@sp-api-sdk/vendor-direct-fulfillment-transactions-api-2021-12-28`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-transactions-api-2021-12-28)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-transactions-api-2021-12-28)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/README.md
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-direct-fulfillment-transactions-api-v1`
+# `@sp-api-sdk/vendor-direct-fulfillment-transactions-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-transactions-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-transactions-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-invoices-api-v1/README.md
+++ b/clients/vendor-invoices-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-invoices-api-v1`
+# `@sp-api-sdk/vendor-invoices-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-invoices-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-invoices-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-orders-api-v1/README.md
+++ b/clients/vendor-orders-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-orders-api-v1`
+# `@sp-api-sdk/vendor-orders-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-orders-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-orders-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-shipments-api-v1/README.md
+++ b/clients/vendor-shipments-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-shipments-api-v1`
+# `@sp-api-sdk/vendor-shipments-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-shipments-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-shipments-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/clients/vendor-transaction-status-api-v1/README.md
+++ b/clients/vendor-transaction-status-api-v1/README.md
@@ -1,4 +1,4 @@
-# `vendor-transaction-status-api-v1`
+# `@sp-api-sdk/vendor-transaction-status-api-v1`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-transaction-status-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/vendor-transaction-status-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)

--- a/codegen/templates/README.md.mustache
+++ b/codegen/templates/README.md.mustache
@@ -1,4 +1,4 @@
-# `{{packageName}}`
+# `@sp-api-sdk/{{packageName}}`
 
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/{{packageName}})](https://www.npmjs.com/package/@sp-api-sdk/{{packageName}})
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)


### PR DESCRIPTION
## Summary
- Update the client README Mustache template to prefix the H1 title with `@sp-api-sdk/`
- Re-apply the prefix to all 63 existing client READMEs so they match the next codegen run

Generated client READMEs now use the real npm package name as their title, matching the convention already used by the hand-written `@sp-api-sdk/auth`, `@sp-api-sdk/common`, `@sp-api-sdk/schemas`, and `@sp-api-sdk/generator` READMEs.

## Test plan
- [x] Spot-check a few rendered READMEs on GitHub to confirm the new title
- [x] Confirm the next codegen run produces the prefixed title