### PR TITLE
chore(codegen): use path filter for schemas xo command

### DIFF
--- a/codegen/generate.ts
+++ b/codegen/generate.ts
@@ -26,7 +26,7 @@ if (generators.has('clients')) {
 if (generators.has('schemas')) {
   console.info('Generating schemas…')
   await generateSchemas()
-  await runCommand('pnpm --filter schemas xo --fix')
+  await runCommand('pnpm --filter "./packages/schemas" xo --fix')
 }
 
 await fs.rm('selling-partner-api-models', {recursive: true})


### PR DESCRIPTION
## Summary
- Switch the `pnpm --filter` argument used to lint generated schemas from the package name `schemas` to the workspace path `./packages/schemas`.

## Test plan
- [x] `pnpm codegen schemas` still lints the schemas package successfully