### PR TITLE
chore: bump pnpm to 11.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "typescript": "^5.9.3",
     "xo": "^1.2.3"
   },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,12 @@ packages:
   - "packages/*"
   - "clients/*"
   - "internal/*"
+
+allowBuilds:
+  "@nestjs/core": false
+  "@openapitools/openapi-generator-cli": false
+  "@swc/core": false
+  esbuild: false
+  unrs-resolver: false
+
+minimumReleaseAge: 0


### PR DESCRIPTION
## Summary

- Bumps `packageManager` from `pnpm@10.33.2` to `pnpm@11.1.3`
- Adds the pnpm v11 `allowBuilds` allow-list to `pnpm-workspace.yaml` (replaces v10's `onlyBuiltDependencies`), explicitly disabling postinstall scripts for `@nestjs/core`, `@openapitools/openapi-generator-cli`, `@swc/core`, `esbuild`, and `unrs-resolver`
- Sets `minimumReleaseAge: 0` (pnpm v11 default is non-zero)

## Test plan

- [x] `pnpm install` succeeds locally on Node 24
- [x] `pnpm -r xo`, `pnpm check:ts`, and `pnpm test` pass in CI
- [x] `pnpm build` succeeds