### PR TITLE
chore: prepare tsconfigs for typescript 6

### DIFF
--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/tsconfig.es.json
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/aplus-content-api-2020-11-01/tsconfig.es.json
+++ b/clients/aplus-content-api-2020-11-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/application-integrations-api-2024-04-01/tsconfig.es.json
+++ b/clients/application-integrations-api-2024-04-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/application-management-api-2023-11-30/tsconfig.es.json
+++ b/clients/application-management-api-2023-11-30/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/catalog-items-api-2020-12-01/tsconfig.es.json
+++ b/clients/catalog-items-api-2020-12-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/catalog-items-api-2022-04-01/tsconfig.es.json
+++ b/clients/catalog-items-api-2022-04-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/catalog-items-api-v0/tsconfig.es.json
+++ b/clients/catalog-items-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/customer-feedback-api-2024-06-01/tsconfig.es.json
+++ b/clients/customer-feedback-api-2024-06-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/data-kiosk-api-2023-11-15/tsconfig.es.json
+++ b/clients/data-kiosk-api-2023-11-15/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/tsconfig.es.json
+++ b/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/easy-ship-api-2022-03-23/tsconfig.es.json
+++ b/clients/easy-ship-api-2022-03-23/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/external-fulfillment-inventory-api-2024-09-11/tsconfig.es.json
+++ b/clients/external-fulfillment-inventory-api-2024-09-11/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/external-fulfillment-returns-api-2024-09-11/tsconfig.es.json
+++ b/clients/external-fulfillment-returns-api-2024-09-11/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/external-fulfillment-shipments-api-2024-09-11/tsconfig.es.json
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/fba-inbound-eligibility-api-v1/tsconfig.es.json
+++ b/clients/fba-inbound-eligibility-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/fba-inventory-api-v1/tsconfig.es.json
+++ b/clients/fba-inventory-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/feeds-api-2021-06-30/tsconfig.es.json
+++ b/clients/feeds-api-2021-06-30/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/finances-api-2024-06-19/tsconfig.es.json
+++ b/clients/finances-api-2024-06-19/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/finances-api-v0/tsconfig.es.json
+++ b/clients/finances-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/finances-transfers-api-2024-06-01/tsconfig.es.json
+++ b/clients/finances-transfers-api-2024-06-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/fulfillment-inbound-api-2024-03-20/tsconfig.es.json
+++ b/clients/fulfillment-inbound-api-2024-03-20/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/fulfillment-inbound-api-v0/tsconfig.es.json
+++ b/clients/fulfillment-inbound-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/fulfillment-outbound-api-2020-07-01/tsconfig.es.json
+++ b/clients/fulfillment-outbound-api-2020-07-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/invoices-api-2024-06-19/tsconfig.es.json
+++ b/clients/invoices-api-2024-06-19/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/listings-items-api-2020-09-01/tsconfig.es.json
+++ b/clients/listings-items-api-2020-09-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/listings-items-api-2021-08-01/tsconfig.es.json
+++ b/clients/listings-items-api-2021-08-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/listings-restrictions-api-2021-08-01/tsconfig.es.json
+++ b/clients/listings-restrictions-api-2021-08-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/merchant-fulfillment-api-v0/tsconfig.es.json
+++ b/clients/merchant-fulfillment-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/messaging-api-v1/tsconfig.es.json
+++ b/clients/messaging-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/notifications-api-v1/tsconfig.es.json
+++ b/clients/notifications-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/orders-api-2026-01-01/tsconfig.es.json
+++ b/clients/orders-api-2026-01-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/orders-api-v0/tsconfig.es.json
+++ b/clients/orders-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/product-fees-api-v0/tsconfig.es.json
+++ b/clients/product-fees-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/product-pricing-api-2022-05-01/tsconfig.es.json
+++ b/clients/product-pricing-api-2022-05-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/product-pricing-api-v0/tsconfig.es.json
+++ b/clients/product-pricing-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/product-type-definitions-api-2020-09-01/tsconfig.es.json
+++ b/clients/product-type-definitions-api-2020-09-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/replenishment-api-2022-11-07/tsconfig.es.json
+++ b/clients/replenishment-api-2022-11-07/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/reports-api-2021-06-30/tsconfig.es.json
+++ b/clients/reports-api-2021-06-30/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/sales-api-v1/tsconfig.es.json
+++ b/clients/sales-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/seller-wallet-api-2024-03-01/tsconfig.es.json
+++ b/clients/seller-wallet-api-2024-03-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/sellers-api-v1/tsconfig.es.json
+++ b/clients/sellers-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/services-api-v1/tsconfig.es.json
+++ b/clients/services-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/shipment-invoicing-api-v0/tsconfig.es.json
+++ b/clients/shipment-invoicing-api-v0/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/shipping-api-v1/tsconfig.es.json
+++ b/clients/shipping-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/shipping-api-v2/tsconfig.es.json
+++ b/clients/shipping-api-v2/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/solicitations-api-v1/tsconfig.es.json
+++ b/clients/solicitations-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/supply-sources-api-2020-07-01/tsconfig.es.json
+++ b/clients/supply-sources-api-2020-07-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/tokens-api-2021-03-01/tsconfig.es.json
+++ b/clients/tokens-api-2021-03-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/uploads-api-2020-11-01/tsconfig.es.json
+++ b/clients/uploads-api-2020-11-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vehicles-api-2024-11-01/tsconfig.es.json
+++ b/clients/vehicles-api-2024-11-01/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-orders-api-v1/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-payments-api-v1/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/tsconfig.es.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-invoices-api-v1/tsconfig.es.json
+++ b/clients/vendor-invoices-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-orders-api-v1/tsconfig.es.json
+++ b/clients/vendor-orders-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-shipments-api-v1/tsconfig.es.json
+++ b/clients/vendor-shipments-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/clients/vendor-transaction-status-api-v1/tsconfig.es.json
+++ b/clients/vendor-transaction-status-api-v1/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/codegen/templates/tsconfig.es.json.mustache
+++ b/codegen/templates/tsconfig.es.json.mustache
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/internal/typescript-config/commonjs.json
+++ b/internal/typescript-config/commonjs.json
@@ -3,7 +3,6 @@
   "extends": "@tsconfig/node24/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "downlevelIteration": true,
     "incremental": true
   }
 }

--- a/internal/typescript-config/esm.json
+++ b/internal/typescript-config/esm.json
@@ -3,7 +3,7 @@
   "extends": "./commonjs.json",
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "declaration": false,
     "declarationDir": null
   }

--- a/packages/auth/tsconfig.es.json
+++ b/packages/auth/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/packages/common/tsconfig.es.json
+++ b/packages/common/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]

--- a/packages/schemas/tsconfig.es.json
+++ b/packages/schemas/tsconfig.es.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@sp-api-sdk/typescript-config/esm.json",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "dist/es"
   },
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## Summary

Address the three TypeScript 6 deprecations / default changes that affect this repo, ahead of the actual `^5.9.3` → `^6.0.0` bump. All changes are backwards-compatible with TS 5.9.

- Drop `downlevelIteration` from the shared CJS config — it only applies to `target: es5`, which is itself deprecated; base targets es2024.
- Switch the shared ESM config from `moduleResolution: node` (deprecated, a.k.a. `node10`) to `bundler` — the modern equivalent that preserves extensionless imports.
- Add `rootDir: "src"` to every `tsconfig.es.json` and the codegen ESM template. TS6 changes the default from inferred to `.`, which would otherwise emit to `dist/es/src/...`.

Reference: [TS 6.0 announcement blog](https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/) (the official `aka.ms/ts6` migration guide is still a placeholder).

## Test plan

- [x] `pnpm check:ts` — 69/69 packages pass
- [x] `pnpm build` — 66/66 packages build, ESM output structure unchanged (`dist/es/index.js`, not `dist/es/src/index.js`)
- [x] `pnpm -r xo` — lint passes