### PR TITLE
ci: add from-package recovery mode to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      from-package:
+        description: "Publish from package.json (recovery mode for partial failures)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency: release
 
@@ -48,7 +53,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
         run: |
-          if [ "${{ github.event.inputs.force-patch-release }}" = "true" ]; then
+          if [ "${{ github.event.inputs.from-package }}" = "true" ]; then
+            pnpm lerna publish from-package --yes;
+          elif [ "${{ github.event.inputs.force-patch-release }}" = "true" ]; then
             pnpm lerna publish --force-publish --bump patch --skip-bump-only-releases --yes;
           else
             pnpm lerna publish --skip-bump-only-releases --yes;


### PR DESCRIPTION
## Summary

Adds a `from-package` boolean input to the Release workflow. When set, runs `lerna publish from-package --yes`, which compares each workspace `package.json` version against npm and publishes only the missing ones.

Motivates a clean recovery path for partial publish failures — e.g. the Sigstore Rekor 409 (`TLOG_CREATE_ENTRY_ERROR`) that aborted run [26521322645](https://github.com/bizon/selling-partner-api-sdk/actions/runs/26521322645) after 13 of 69 packages had published. In that state, plain `lerna publish` sees no new commits since the tags and refuses to publish the remaining 56; `from-package` is the standard lerna recovery mode for this scenario.

Provenance still flows through CI OIDC, so re-published packages stay consistent with the ones already on npm.

## Test plan

- [ ] Merge to master
- [ ] Dispatch Release with `from-package=true` to publish the remaining packages from run 26521322645
- [ ] Confirm the 13 already-published packages are skipped and the rest publish successfully