### PR TITLE
chore: remove unused ts-node dependency

### DIFF
--- a/codegen/tsconfig.json
+++ b/codegen/tsconfig.json
@@ -3,8 +3,5 @@
   "compilerOptions": {
     "resolveJsonModule": true
   },
-  "ts-node": {
-    "esm": true
-  },
   "include": ["**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "eslint-config-xo-bizon": "^4.3.0",
     "jest": "^30.4.2",
     "jest-junit": "^17.0.0",
-    "ts-node": "^10.9.2",
     "tsdown": "^0.22.3",
     "tsx": "^4.22.4",
     "turbo": "^2.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       jest-junit:
         specifier: ^17.0.0
         version: 17.0.0
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.15.46)(@types/node@24.12.4)(typescript@5.9.3)
       tsdown:
         specifier: ^0.22.3
         version: 0.22.3(tsx@4.22.4)(typescript@5.9.3)
@@ -1705,9 +1702,6 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.4.15':
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -2614,11 +2608,6 @@ packages:
   acorn-walk@8.3.2:
     resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
     engines: {node: '>=0.4.0'}
-
-  acorn@8.11.3:
-    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -6205,6 +6194,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@dabh/diagnostics@2.0.8':
     dependencies:
@@ -6714,8 +6704,6 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.4.15': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
@@ -6726,7 +6714,8 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optional: true
 
   '@lerna-lite/cli@5.4.1(@lerna-lite/publish@5.4.1(@types/node@24.12.4)(conventional-commits-filter@6.0.1)(supports-color@8.1.1))(@lerna-lite/version@5.4.1(@lerna-lite/publish@5.4.1(@types/node@24.12.4)(conventional-commits-filter@6.0.1)(supports-color@8.1.1))(@types/node@24.12.4)(conventional-commits-filter@6.0.1))(@types/node@24.12.4)':
     dependencies:
@@ -7380,13 +7369,17 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tsconfig/node24@24.0.4': {}
 
@@ -7691,9 +7684,8 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.2: {}
-
-  acorn@8.11.3: {}
+  acorn-walk@8.3.2:
+    optional: true
 
   acorn@8.15.0: {}
 
@@ -7739,7 +7731,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -8178,7 +8171,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8273,7 +8267,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   doctrine@2.1.0:
     dependencies:
@@ -9922,7 +9917,8 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   make-fetch-happen@15.0.6(supports-color@8.1.1):
     dependencies:
@@ -11146,7 +11142,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 24.12.4
-      acorn: 8.11.3
+      acorn: 8.15.0
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -11157,6 +11153,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.46
+    optional: true
 
   tsdown@0.22.3(tsx@4.22.4)(typescript@5.9.3):
     dependencies:
@@ -11396,7 +11393,8 @@ snapshots:
 
   uuid@14.0.0: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -11640,7 +11638,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
`ts-node` was added in 2ab254a to run the codegen TypeScript scripts. #1074 then switched the codegen entrypoint to `tsx`, but left behind both the devDependency and the `"ts-node": { "esm": true }` block in `codegen/tsconfig.json`. Neither is referenced by anything today.

The one remaining place it could plausibly matter is Jest loading the `jest.config.ts` files. It doesn't: Jest 30 uses native TypeScript support when `process.features.typescript` is set — true on this repo's Node 24 — and only falls back to a ts-node loader otherwise.

Verified by temporarily removing `ts-node` from the store and re-running Jest: the config loaded fine and output was identical.

### Checks

- `pnpm -r xo` — pass
- `pnpm check:ts` — 69/69 pass
- `pnpm test` — 4/4 pass, 19 tests
- `tsc --noEmit -p codegen/tsconfig.json` — pass

Also drops ts-node's transitive tree from the lockfile (`@cspotcode/source-map-support`, `@tsconfig/*`, `acorn-walk`, `arg`, `create-require`, `diff`, `v8-compile-cache-lib`, `yn`).