### PR TITLE
chore: migrate xo config to typescript

### DIFF
--- a/xo.config.ts
+++ b/xo.config.ts
@@ -1,23 +1,21 @@
 import xoBizon from 'eslint-config-xo-bizon'
+import {type FlatXoConfig} from 'xo'
 
-/** @type {import('xo').FlatXoConfig} */
 export default [
   ...xoBizon,
+
   {
-    ignores: [
-      'clients/*/src/api-model/**',
-      'packages/schemas/src/**',
-      '**/CHANGELOG.md',
-      '**/tsdown.config.ts',
-    ],
+    ignores: ['clients/*/src/api-model/**', 'packages/schemas/src/**', '**/CHANGELOG.md'],
   },
+
   {
     settings: {
       'import-x/internal-regex': '^@sp-api-sdk/',
     },
   },
+
   {
-    files: ['**/*.{js,ts}'],
+    files: ['**/*.ts'],
     rules: {
       'import-x/extensions': 'off',
       'n/prefer-global/url': 'off',
@@ -47,4 +45,4 @@ export default [
       ],
     },
   },
-]
+] satisfies FlatXoConfig


### PR DESCRIPTION
XO 4 loads TypeScript configs through `jiti`, so `xo.config.js` becomes `xo.config.ts` and the export is typed with `satisfies FlatXoConfig` instead of a JSDoc annotation.

Two behaviour changes come along with the rename:

- **`**/tsdown.config.ts` is no longer ignored** — the 67 generated tsdown configs lint clean today, and covering them turns a regression in `codegen/templates/` into a lint failure.
- **`['**/*.{js,ts}']` narrowed to `['**/*.ts']`** — `xo.config.js` was the last tracked JS file in the repo.

`pnpm xo` passes: 289 files, 0 errors, the same 27 pre-existing warnings as on master.