### PR TITLE
feat(common): drop vestigial awsRegion from regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,3 @@ clients/**/dist
 packages/**/dist
 
 selling-partner-api-models/
-
-packages/test-sdk
-clients-test/

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -25,7 +25,6 @@ interface RateLimit {
   rate: number
   burst: number
   urlRegex: string
-  last?: boolean
 }
 
 interface ClientInfo {
@@ -230,10 +229,6 @@ async function generateClientVersion(modelFilePath: string): Promise<ClientInfo>
     },
     [],
   )
-
-  if (rateLimits.length > 0) {
-    rateLimits.at(-1)!.last = true
-  }
 
   await fs.writeFile(
     `${clientDirectoryPath}/tsconfig.json`,

--- a/codegen/generate-schemas.ts
+++ b/codegen/generate-schemas.ts
@@ -82,7 +82,7 @@ async function generateDirectoryIndex(schemas: SchemaFile[], outputDirectory: st
   await fs.writeFile(`${outputDirectory}/index.ts`, body)
 }
 
-export async function generateDirectorySchemas(schemaDirectory: string, directoryName: string) {
+async function generateDirectorySchemas(schemaDirectory: string, directoryName: string) {
   const schemaFilePaths = await globby('*.json', {
     onlyFiles: true,
     cwd: schemaDirectory,

--- a/internal/typescript-config/package.json
+++ b/internal/typescript-config/package.json
@@ -13,6 +13,7 @@
   ],
   "dependencies": {
     "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^24.12.4",
     "tsdown": "^0.22.12"
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -9,6 +9,7 @@
     },
     "version": {
       "conventionalCommits": true,
+      "changelogPreset": "conventionalcommits",
       "createRelease": "github",
       "syncWorkspaceLock": true,
       "message": "chore(release): publish [skip ci]"

--- a/packages/common/src/regions.ts
+++ b/packages/common/src/regions.ts
@@ -2,31 +2,27 @@
 export type SellingPartnerRegion = 'na' | 'eu' | 'fe'
 
 interface RegionConfiguration {
-  awsRegion: string
   endpoints: {
     production: string
     sandbox: string
   }
 }
 
-/** AWS region and endpoint mapping for each Selling Partner API region. */
+/** Endpoint mapping for each Selling Partner API region. */
 export const sellingPartnerRegions: Record<SellingPartnerRegion, RegionConfiguration> = {
   na: {
-    awsRegion: 'us-east-1',
     endpoints: {
       production: 'https://sellingpartnerapi-na.amazon.com',
       sandbox: 'https://sandbox.sellingpartnerapi-na.amazon.com',
     },
   },
   eu: {
-    awsRegion: 'eu-west-1',
     endpoints: {
       production: 'https://sellingpartnerapi-eu.amazon.com',
       sandbox: 'https://sandbox.sellingpartnerapi-eu.amazon.com',
     },
   },
   fe: {
-    awsRegion: 'us-west-2',
     endpoints: {
       production: 'https://sellingpartnerapi-fe.amazon.com',
       sandbox: 'https://sandbox.sellingpartnerapi-fe.amazon.com',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -942,6 +942,9 @@ importers:
       '@tsconfig/node24':
         specifier: ^24.0.4
         version: 24.0.4
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.13.3
       tsdown:
         specifier: ^0.22.12
         version: 0.22.12(tsx@4.23.1)(typescript@6.0.3)
@@ -6642,7 +6645,7 @@ snapshots:
   '@jest/console@30.4.1':
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       jest-message-util: 30.4.1
       jest-util: 30.4.1
@@ -6656,7 +6659,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(supports-color@10.2.2)
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
@@ -6664,7 +6667,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11
       jest-changed-files: 30.4.1
-      jest-config: 30.4.2(@types/node@24.12.4)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.46)(@types/node@24.12.4)(typescript@6.0.3))
+      jest-config: 30.4.2(@types/node@24.13.3)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.46)(@types/node@24.12.4)(typescript@6.0.3))
       jest-haste-map: 30.4.1
       jest-message-util: 30.4.1
       jest-regex-util: 30.4.0
@@ -6694,7 +6697,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-mock: 30.4.1
 
   '@jest/expect-utils@30.4.1':
@@ -6712,7 +6715,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-message-util: 30.4.1
       jest-mock: 30.4.1
       jest-util: 30.4.1
@@ -6730,12 +6733,12 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-regex-util: 30.0.1
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-regex-util: 30.4.0
 
   '@jest/reporters@30.4.1(supports-color@10.2.2)':
@@ -6746,7 +6749,7 @@ snapshots:
       '@jest/transform': 30.4.1(supports-color@10.2.2)
       '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -6826,7 +6829,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -9387,7 +9390,7 @@ snapshots:
       '@jest/expect': 30.4.1(supports-color@10.2.2)
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -9458,6 +9461,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.4.2(@types/node@24.13.3)(supports-color@10.2.2)(ts-node@10.9.2(@swc/core@1.15.46)(@types/node@24.12.4)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.4.2(supports-color@10.2.2)
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.13.3
+      ts-node: 10.9.2(@swc/core@1.15.46)(@types/node@24.12.4)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -9482,7 +9517,7 @@ snapshots:
       '@jest/environment': 30.4.1
       '@jest/fake-timers': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-mock: 30.4.1
       jest-util: 30.4.1
       jest-validate: 30.4.1
@@ -9490,7 +9525,7 @@ snapshots:
   jest-haste-map@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9537,7 +9572,7 @@ snapshots:
   jest-mock@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       jest-util: 30.4.1
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
@@ -9573,7 +9608,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(supports-color@10.2.2)
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -9602,7 +9637,7 @@ snapshots:
       '@jest/test-result': 30.4.1
       '@jest/transform': 30.4.1(supports-color@10.2.2)
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -9649,7 +9684,7 @@ snapshots:
   jest-util@30.4.1:
     dependencies:
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -9668,7 +9703,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.4.1
       '@jest/types': 30.4.1
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -9677,7 +9712,7 @@ snapshots:
 
   jest-worker@30.4.1:
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.3
       '@ungap/structured-clone': 1.3.1
       jest-util: 30.4.1
       merge-stream: 2.0.0


### PR DESCRIPTION
Removes unused code and dependencies found while auditing the hand-written
surface (`packages/auth`, `packages/common`, `codegen/`, `internal/`, root
config). Generated code — `clients/`, `packages/schemas/src/`,
`clients/*/src/api-model/` — was excluded.

> [!IMPORTANT]
> **Merge with squash, and keep the `BREAKING CHANGE:` footer in the commit body.**
> This repo builds the squash body from commit messages, so the footer carries
> over automatically from `feat(common): drop vestigial awsRegion from regions`.
> If you hand-edit the squash message, preserve that footer — lerna needs it to
> major-bump `@sp-api-sdk/common`.

## Breaking

`sellingPartnerRegions[region].awsRegion` is removed. It had been unused since
AWS4 request signing was dropped in #997, but stayed exported as part of the
public `sellingPartnerRegions` object. Consumers reading it must inline the
value instead (`na: us-east-1`, `eu: eu-west-1`, `fe: us-west-2`).

## Non-breaking cleanups

- Drop unused `RateLimit.last` from codegen — it was set on the last rate limit,
  but no Mustache template ever read it.
- Unexport `generateDirectorySchemas`; it is only used within its own module.
- Declare `@types/node` in `@sp-api-sdk/typescript-config`, which sets
  `types: ["node"]` but relied on the root devDependency to resolve it.
- Set lerna `changelogPreset` to `conventionalcommits`. The package was already
  a devDependency but nothing loaded it, so releases silently used the `angular`
  default. Note this changes CHANGELOG section headings going forward, so new
  entries will not match existing ones stylistically.
- Drop stale `.gitignore` entries (`packages/test-sdk`, `clients-test/`) for
  paths that no longer exist.

## Checks

`pnpm xo` (0 errors; 27 pre-existing warnings), `pnpm check:ts` 69/69,
`pnpm test` 29 passed.
