### PR TITLE
docs: resolve marketplace ids with @bizon/amazon-ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ npm install @sp-api-sdk/auth @sp-api-sdk/orders-api-2026-01-01
 
 ### Usage
 
-```javascript
+```typescript
+import {getMarketplaceByCode} from '@bizon/amazon-ids'
 import {SellingPartnerApiAuth} from '@sp-api-sdk/auth'
 import {OrdersApiClient} from '@sp-api-sdk/orders-api-2026-01-01'
+
+const de = getMarketplaceByCode('de')!
 
 // `clientId` and `clientSecret` default to the `LWA_CLIENT_ID` and
 // `LWA_CLIENT_SECRET` environment variables.
@@ -65,10 +68,14 @@ const client = new OrdersApiClient({
 })
 
 const {data} = await client.searchOrders({
-  marketplaceIds: ['A1PA6795UKMFR9'],
+  marketplaceIds: [de.id],
   createdAfter: '2026-01-01T00:00:00Z',
 })
 ```
+
+> Marketplace identifiers are not part of this SDK. The examples resolve them with
+> [`@bizon/amazon-ids`](https://github.com/bizon/amazon-ids) (`npm install @bizon/amazon-ids`), a small
+> package mapping country codes and domains to Amazon marketplaces.
 
 ### Configuration
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -45,11 +45,11 @@ import {type ClientConfiguration} from '@sp-api-sdk/common'
 
 Three regions are supported, each with production and sandbox endpoints:
 
-| Region        | Code | AWS Region | Production Endpoint                       |
-| ------------- | ---- | ---------- | ----------------------------------------- |
-| North America | `na` | us-east-1  | `https://sellingpartnerapi-na.amazon.com` |
-| Europe        | `eu` | eu-west-1  | `https://sellingpartnerapi-eu.amazon.com` |
-| Far East      | `fe` | us-west-2  | `https://sellingpartnerapi-fe.amazon.com` |
+| Region        | Code | Production Endpoint                       |
+| ------------- | ---- | ----------------------------------------- |
+| North America | `na` | `https://sellingpartnerapi-na.amazon.com` |
+| Europe        | `eu` | `https://sellingpartnerapi-eu.amazon.com` |
+| Far East      | `fe` | `https://sellingpartnerapi-fe.amazon.com` |
 
 When `sandbox` is set to `true`, the sandbox variant of the endpoint is used (e.g. `https://sandbox.sellingpartnerapi-eu.amazon.com`).
 
@@ -95,10 +95,13 @@ By default, `request` and `response` loggers use `console.info`, and the `error`
 API errors are wrapped in `SellingPartnerApiError`, which extends `AxiosError` and adds context:
 
 ```typescript
+import {getMarketplaceByCode} from '@bizon/amazon-ids'
 import {SellingPartnerApiError} from '@sp-api-sdk/common'
 
+const de = getMarketplaceByCode('de')!
+
 try {
-  await client.searchOrders({marketplaceIds: ['A1PA6795UKMFR9']})
+  await client.searchOrders({marketplaceIds: [de.id]})
 } catch (error) {
   if (error instanceof SellingPartnerApiError) {
     console.error(error.message) // e.g. "orders (2026-01-01) error: Response code 403"


### PR DESCRIPTION
## What

The README examples hardcoded the German marketplace identifier
(`A1PA6795UKMFR9`). They now resolve it through
[`@bizon/amazon-ids`](https://github.com/bizon/amazon-ids):

```typescript
const de = getMarketplaceByCode('de')!

const {data} = await client.searchOrders({
  marketplaceIds: [de.id],
  createdAfter: '2026-01-01T00:00:00Z',
})
```

A short note makes it clear marketplace identifiers are not part of this
SDK and that the package is an optional helper.

Applies to the root `README.md` (usage example, fence switched to
`typescript` for the non-null assertion) and
`packages/common/README.md` (error-handling example).

## Also

Drops the `AWS Region` column from the regions table in
`packages/common/README.md` — `awsRegion` was removed from
`sellingPartnerRegions` in #1832, so the table documented a property
that no longer exists.