### PR TITLE
fix: correct package metadata and keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/bizon/selling-partner-api-sdk/branch/master/graph/badge.svg?token=tqBs3JHHP2)](https://codecov.io/gh/bizon/selling-partner-api-sdk)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
-A modularized SDK library for Amazon Selling Partner API (fully typed in TypeScript)
+Modularized, fully-typed TypeScript SDK for the Amazon Selling Partner API (SP-API), with independently versioned clients regenerated daily.
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)
 

--- a/clients/amazon-warehousing-and-distribution-api-2024-05-09/package.json
+++ b/clients/amazon-warehousing-and-distribution-api-2024-05-09/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/amazon-warehousing-and-distribution-api-2024-05-09",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "amazon warehousing and distribution api"
   ]
 }

--- a/clients/aplus-content-api-2020-11-01/package.json
+++ b/clients/aplus-content-api-2020-11-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/aplus-content-api-2020-11-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "aplus content api"
   ]
 }

--- a/clients/application-integrations-api-2024-04-01/package.json
+++ b/clients/application-integrations-api-2024-04-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/application-integrations-api-2024-04-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "application integrations api"
   ]
 }

--- a/clients/application-management-api-2023-11-30/package.json
+++ b/clients/application-management-api-2023-11-30/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/application-management-api-2023-11-30",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "application management api"
   ]
 }

--- a/clients/catalog-items-api-2020-12-01/package.json
+++ b/clients/catalog-items-api-2020-12-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/catalog-items-api-2020-12-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "catalog items api"
   ]
 }

--- a/clients/catalog-items-api-2022-04-01/package.json
+++ b/clients/catalog-items-api-2022-04-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/catalog-items-api-2022-04-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "catalog items api"
   ]
 }

--- a/clients/catalog-items-api-v0/package.json
+++ b/clients/catalog-items-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/catalog-items-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "catalog items api"
   ]
 }

--- a/clients/customer-feedback-api-2024-06-01/package.json
+++ b/clients/customer-feedback-api-2024-06-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/customer-feedback-api-2024-06-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "customer feedback api"
   ]
 }

--- a/clients/data-kiosk-api-2023-11-15/package.json
+++ b/clients/data-kiosk-api-2023-11-15/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/data-kiosk-api-2023-11-15",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "data kiosk api"
   ]
 }

--- a/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/package.json
+++ b/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/delivery-by-amazon-delivery-shipment-invoice-v2022-07-01-api-2022-07-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "delivery by amazon delivery shipment invoice v2022 07 01 api"
   ]
 }

--- a/clients/easy-ship-api-2022-03-23/package.json
+++ b/clients/easy-ship-api-2022-03-23/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/easy-ship-api-2022-03-23",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "easy ship api"
   ]
 }

--- a/clients/external-fulfillment-inventory-api-2024-09-11/package.json
+++ b/clients/external-fulfillment-inventory-api-2024-09-11/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/external-fulfillment-inventory-api-2024-09-11",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "external fulfillment inventory api"
   ]
 }

--- a/clients/external-fulfillment-returns-api-2024-09-11/package.json
+++ b/clients/external-fulfillment-returns-api-2024-09-11/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/external-fulfillment-returns-api-2024-09-11",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "external fulfillment returns api"
   ]
 }

--- a/clients/external-fulfillment-shipments-api-2024-09-11/package.json
+++ b/clients/external-fulfillment-shipments-api-2024-09-11/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/external-fulfillment-shipments-api-2024-09-11",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "external fulfillment shipments api"
   ]
 }

--- a/clients/fba-inbound-eligibility-api-v1/package.json
+++ b/clients/fba-inbound-eligibility-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/fba-inbound-eligibility-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "fba inbound eligibility api"
   ]
 }

--- a/clients/fba-inventory-api-v1/package.json
+++ b/clients/fba-inventory-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/fba-inventory-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "fba inventory api"
   ]
 }

--- a/clients/feeds-api-2021-06-30/package.json
+++ b/clients/feeds-api-2021-06-30/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/feeds-api-2021-06-30",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "feeds api"
   ]
 }

--- a/clients/finances-api-2024-06-19/package.json
+++ b/clients/finances-api-2024-06-19/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/finances-api-2024-06-19",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "finances api"
   ]
 }

--- a/clients/finances-api-v0/package.json
+++ b/clients/finances-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/finances-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "finances api"
   ]
 }

--- a/clients/finances-transfers-api-2024-06-01/package.json
+++ b/clients/finances-transfers-api-2024-06-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/finances-transfers-api-2024-06-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "finances transfers api"
   ]
 }

--- a/clients/fulfillment-inbound-api-2024-03-20/package.json
+++ b/clients/fulfillment-inbound-api-2024-03-20/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/fulfillment-inbound-api-2024-03-20",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "fulfillment inbound api"
   ]
 }

--- a/clients/fulfillment-inbound-api-v0/package.json
+++ b/clients/fulfillment-inbound-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/fulfillment-inbound-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "fulfillment inbound api"
   ]
 }

--- a/clients/fulfillment-outbound-api-2020-07-01/package.json
+++ b/clients/fulfillment-outbound-api-2020-07-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/fulfillment-outbound-api-2020-07-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "fulfillment outbound api"
   ]
 }

--- a/clients/invoices-api-2024-06-19/package.json
+++ b/clients/invoices-api-2024-06-19/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/invoices-api-2024-06-19",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "invoices api"
   ]
 }

--- a/clients/listings-items-api-2020-09-01/package.json
+++ b/clients/listings-items-api-2020-09-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/listings-items-api-2020-09-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "listings items api"
   ]
 }

--- a/clients/listings-items-api-2021-08-01/package.json
+++ b/clients/listings-items-api-2021-08-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/listings-items-api-2021-08-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "listings items api"
   ]
 }

--- a/clients/listings-restrictions-api-2021-08-01/package.json
+++ b/clients/listings-restrictions-api-2021-08-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/listings-restrictions-api-2021-08-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "listings restrictions api"
   ]
 }

--- a/clients/merchant-fulfillment-api-v0/package.json
+++ b/clients/merchant-fulfillment-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/merchant-fulfillment-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "merchant fulfillment api"
   ]
 }

--- a/clients/messaging-api-v1/package.json
+++ b/clients/messaging-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/messaging-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "messaging api"
   ]
 }

--- a/clients/notifications-api-v1/package.json
+++ b/clients/notifications-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/notifications-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "notifications api"
   ]
 }

--- a/clients/orders-api-2026-01-01/package.json
+++ b/clients/orders-api-2026-01-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/orders-api-2026-01-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "orders api"
   ]
 }

--- a/clients/orders-api-v0/package.json
+++ b/clients/orders-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/orders-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "orders api"
   ]
 }

--- a/clients/product-fees-api-v0/package.json
+++ b/clients/product-fees-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-fees-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "product fees api"
   ]
 }

--- a/clients/product-pricing-api-2022-05-01/package.json
+++ b/clients/product-pricing-api-2022-05-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-pricing-api-2022-05-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "product pricing api"
   ]
 }

--- a/clients/product-pricing-api-v0/package.json
+++ b/clients/product-pricing-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-pricing-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "product pricing api"
   ]
 }

--- a/clients/product-type-definitions-api-2020-09-01/package.json
+++ b/clients/product-type-definitions-api-2020-09-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/product-type-definitions-api-2020-09-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "product type definitions api"
   ]
 }

--- a/clients/replenishment-api-2022-11-07/package.json
+++ b/clients/replenishment-api-2022-11-07/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/replenishment-api-2022-11-07",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "replenishment api"
   ]
 }

--- a/clients/reports-api-2021-06-30/package.json
+++ b/clients/reports-api-2021-06-30/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/reports-api-2021-06-30",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "reports api"
   ]
 }

--- a/clients/sales-api-v1/package.json
+++ b/clients/sales-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/sales-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "sales api"
   ]
 }

--- a/clients/seller-wallet-api-2024-03-01/package.json
+++ b/clients/seller-wallet-api-2024-03-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/seller-wallet-api-2024-03-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "seller wallet api"
   ]
 }

--- a/clients/sellers-api-v1/package.json
+++ b/clients/sellers-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/sellers-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "sellers api"
   ]
 }

--- a/clients/services-api-v1/package.json
+++ b/clients/services-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/services-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "services api"
   ]
 }

--- a/clients/shipment-invoicing-api-v0/package.json
+++ b/clients/shipment-invoicing-api-v0/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/shipment-invoicing-api-v0",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "shipment invoicing api"
   ]
 }

--- a/clients/shipping-api-v1/package.json
+++ b/clients/shipping-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/shipping-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "shipping api"
   ]
 }

--- a/clients/shipping-api-v2/package.json
+++ b/clients/shipping-api-v2/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/shipping-api-v2",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "shipping api"
   ]
 }

--- a/clients/solicitations-api-v1/package.json
+++ b/clients/solicitations-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/solicitations-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "solicitations api"
   ]
 }

--- a/clients/supply-sources-api-2020-07-01/package.json
+++ b/clients/supply-sources-api-2020-07-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/supply-sources-api-2020-07-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "supply sources api"
   ]
 }

--- a/clients/tokens-api-2021-03-01/package.json
+++ b/clients/tokens-api-2021-03-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/tokens-api-2021-03-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "tokens api"
   ]
 }

--- a/clients/uploads-api-2020-11-01/package.json
+++ b/clients/uploads-api-2020-11-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/uploads-api-2020-11-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "uploads api"
   ]
 }

--- a/clients/vehicles-api-2024-11-01/package.json
+++ b/clients/vehicles-api-2024-11-01/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vehicles-api-2024-11-01",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vehicles api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-inventory-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-inventory-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment inventory api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-orders-api-2021-12-28/package.json
+++ b/clients/vendor-direct-fulfillment-orders-api-2021-12-28/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-orders-api-2021-12-28",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment orders api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-orders-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-orders-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-orders-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment orders api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-payments-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-payments-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-payments-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment payments api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/package.json
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment sandbox test data api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/package.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-2021-12-28/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-shipping-api-2021-12-28",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment shipping api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-shipping-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-shipping-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment shipping api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/package.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-2021-12-28/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-transactions-api-2021-12-28",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment transactions api"
   ]
 }

--- a/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
+++ b/clients/vendor-direct-fulfillment-transactions-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-direct-fulfillment-transactions-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor direct fulfillment transactions api"
   ]
 }

--- a/clients/vendor-invoices-api-v1/package.json
+++ b/clients/vendor-invoices-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-invoices-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor invoices api"
   ]
 }

--- a/clients/vendor-orders-api-v1/package.json
+++ b/clients/vendor-orders-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-orders-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor orders api"
   ]
 }

--- a/clients/vendor-shipments-api-v1/package.json
+++ b/clients/vendor-shipments-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-shipments-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor shipments api"
   ]
 }

--- a/clients/vendor-transaction-status-api-v1/package.json
+++ b/clients/vendor-transaction-status-api-v1/package.json
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/vendor-transaction-status-api-v1",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "vendor transaction status api"
   ]
 }

--- a/codegen/templates/package.json.mustache
+++ b/codegen/templates/package.json.mustache
@@ -54,12 +54,17 @@
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/clients/{{packageName}}",
   "keywords": [
     "amazon",
+    "amazon-sp-api",
     "bizon",
-    "marketplace web services",
-    "mws",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
+    "selling-partner-api",
     "sp api",
     "sp sdk",
+    "sp-api",
+    "typescript",
     "{{apiName}}"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bizon/selling-partner-api-sdk",
   "private": true,
-  "description": "A modularized SDK library for Amazon Selling Partner API (fully typed in TypeScript)",
+  "description": "Modularized, fully-typed TypeScript SDK for the Amazon Selling Partner API (SP-API), with independently versioned clients regenerated daily",
   "repository": "git@github.com:bizon/selling-partner-api-sdk.git",
   "author": "Bertrand Marron <bertrand@bizon.solutions>",
   "license": "MIT",

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/auth)](https://www.npmjs.com/package/@sp-api-sdk/auth)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
-Amazon Selling Partner API authentication package
+Login with Amazon (LWA) authentication for the Amazon Selling Partner API (SP-API)
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sp-api-sdk/auth",
   "author": "Bertrand Marron <bertrand@bizon.solutions>",
-  "description": "Amazon Selling Partner API authentication package",
+  "description": "Login with Amazon (LWA) authentication for the Amazon Selling Partner API (SP-API)",
   "version": "3.1.0",
   "license": "MIT",
   "type": "module",
@@ -55,13 +55,19 @@
   },
   "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/packages/auth",
   "keywords": [
-    "bizon",
     "amazon",
+    "amazon-sp-api",
     "auth",
-    "spa sdk",
-    "sp api",
-    "mws",
+    "bizon",
+    "esm",
+    "lwa",
+    "nodejs",
+    "sdk",
     "selling partner api",
-    "marketplace webservice"
+    "selling-partner-api",
+    "sp api",
+    "sp sdk",
+    "sp-api",
+    "typescript"
   ]
 }

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/common)](https://www.npmjs.com/package/@sp-api-sdk/common)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
-Amazon Selling Partner API common package
+Common library for the Amazon Selling Partner API (SP-API) SDK: Axios factory, regions, rate limiting and errors
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sp-api-sdk/common",
   "author": "Bertrand Marron <bertrand@bizon.solutions>",
-  "description": "Selling Parner API common library",
+  "description": "Common library for the Amazon Selling Partner API (SP-API) SDK: Axios factory, regions, rate limiting and errors",
   "version": "4.0.0",
   "license": "MIT",
   "type": "module",
@@ -56,14 +56,19 @@
   "bugs": {
     "url": "https://github.com/bizon/selling-partner-api-sdk/issues"
   },
-  "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/packages/auth",
+  "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/packages/common",
   "keywords": [
-    "bizon",
     "amazon",
-    "spa sdk",
-    "sp api",
-    "mws",
+    "amazon-sp-api",
+    "bizon",
+    "esm",
+    "nodejs",
+    "sdk",
     "selling partner api",
-    "marketplace webservice"
+    "selling-partner-api",
+    "sp api",
+    "sp sdk",
+    "sp-api",
+    "typescript"
   ]
 }

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/schemas)](https://www.npmjs.com/package/@sp-api-sdk/schemas)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
-Amazon Selling Partner API schemas
+JSON schemas and TypeScript types for the Amazon Selling Partner API (SP-API)
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)
 

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sp-api-sdk/schemas",
   "author": "Bertrand Marron <bertrand@bizon.solutions>",
-  "description": "Selling Parner API additional schema types",
+  "description": "JSON schemas and TypeScript types for the Amazon Selling Partner API (SP-API)",
   "version": "2.2.0",
   "license": "MIT",
   "type": "module",
@@ -47,19 +47,25 @@
   "bugs": {
     "url": "https://github.com/bizon/selling-partner-api-sdk/issues"
   },
-  "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/packages/notifications",
+  "homepage": "https://github.com/bizon/selling-partner-api-sdk/tree/master/packages/schemas",
   "keywords": [
-    "bizon",
     "amazon",
-    "spa sdk",
-    "sp api",
-    "mws",
-    "selling partner api",
-    "marketplace webservice",
-    "schemas",
+    "amazon-sp-api",
+    "bizon",
     "data kiosk",
+    "esm",
     "feeds",
+    "json-schema",
+    "nodejs",
     "notifications",
-    "reports"
+    "reports",
+    "schemas",
+    "sdk",
+    "selling partner api",
+    "selling-partner-api",
+    "sp api",
+    "sp sdk",
+    "sp-api",
+    "typescript"
   ]
 }


### PR DESCRIPTION
Follow-up to the GitHub topics/description change in `infra` (already applied).

**Keywords** (all 63 clients + `auth`, `common`, `schemas`)

- Drop `mws` / `marketplace web services` / `marketplace webservice` — MWS was retired in 2022.
- Add `amazon-sp-api`, `sp-api`, `selling-partner-api`, `typescript`, `nodejs`, `esm`, `sdk`.

**Bugs found in the core packages**

- `"spa sdk"` was a typo for `"sp sdk"` in `auth`, `common` and `schemas` ("spa" reads as single-page app).
- `common` and `schemas` were described as "Selling **Parner** API" on their npm pages.
- `common`'s `homepage` pointed at `packages/auth`, and `schemas`' at `packages/notifications` — a directory that doesn't exist, so that link 404s.

**Descriptions** now lead with the `SP-API` abbreviation, which was previously absent everywhere. Package READMEs are synced to match.

The 63 client `package.json` files are generated output. They're updated here with the same transform applied to `codegen/templates/package.json.mustache`, so the next codegen run is a no-op — rather than running a full regen, which would have pulled unrelated model changes into this diff.