### PR TITLE
docs: improve docs site metadata

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "name": "Selling Partner API SDK for JavaScript",
+  "name": "Amazon Selling Partner API (SP-API) SDK for TypeScript",
+  "hostedBaseUrl": "https://bizon.github.io/selling-partner-api-sdk/",
   "out": "docs",
   "entryPointStrategy": "packages",
   "entryPoints": ["packages/*", "clients/*"]


### PR DESCRIPTION
The generated docs site had two gaps.

**No sitemap or canonical links.** `sitemap.xml` and `robots.txt` both returned 404 and the HTML carried no `<link rel="canonical">`, because `hostedBaseUrl` was unset — TypeDoc only generates a sitemap when it is set. With 66 packages as entry points the site has thousands of pages that could only be discovered by crawling.

**The title omitted "Amazon".** It read `Selling Partner API SDK for JavaScript` — no brand term, no `SP-API`, and "JavaScript" for a TypeScript-first SDK. `name` drives the `<title>`, the `<meta name="description">` and the site header.

Verified locally against a two-package build:

```
<link rel="canonical" href="https://bizon.github.io/selling-partner-api-sdk/"/>
<title>Amazon Selling Partner API (SP-API) SDK for TypeScript</title>
<meta name="description" content="Documentation for Amazon Selling Partner API (SP-API) SDK for TypeScript"/>
```

plus a `sitemap.xml` with absolute `<loc>` entries.

Note the site only redeploys via the `docs` job in `release.yml`, so this takes effect on the next release run.