### PR TITLE
ci: split docs deployment into its own workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+name: Documentation
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+concurrency: docs
+
+# Checkout and deployment both use BOT_GITHUB_TOKEN_PUBLIC.
+permissions:
+  contents: read
+
+jobs:
+  docs:
+    name: Build and publish documentation
+    # Manual runs always go through; release-triggered ones only on success.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
+          # A release pushes version bumps after it starts, so the event SHA is
+          # already stale: always document the tip of the default branch.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.repository.default_branch || github.ref }}
+
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build documentation
+        run: pnpm run docs
+        env:
+          NODE_OPTIONS: --max_old_space_size=6144
+
+      - name: Deploy documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: docs
+          folder: docs
+          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
+          commit-message: "docs: update documentation"
+          git-config-name: ${{ secrets.BOT_NAME }}
+          git-config-email: ${{ secrets.BOT_EMAIL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,35 +61,5 @@ jobs:
             pnpm lerna publish --skip-bump-only-releases --yes;
           fi
 
-  docs:
-    name: Update and publish documentation
-    needs: release
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
-
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v7
-        with:
-          node-version-file: .node-version
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build documentation
-        run: pnpm run docs
-        env:
-          NODE_OPTIONS: --max_old_space_size=6144
-
-      - name: Deploy documentation
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          branch: docs
-          folder: docs
-          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
-          commit-message: "docs: update documentation"
-          git-config-name: ${{ secrets.BOT_NAME }}
-          git-config-email: ${{ secrets.BOT_EMAIL }}
+# Documentation is built and deployed by the `Documentation` workflow, which
+# runs automatically once this one succeeds (see docs.yml).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,9 @@ pnpm codegen schemas      # generate schemas only
 
 - **Tests** (`tests.yml`): lint + type check + Jest on every PR and push to master
 - **Codegen** (`codegen.yml`): runs twice daily, creates PRs on `codegen/update-models` and `codegen/update-schemas` branches
-- **Release** (`release.yml`): manual workflow dispatch — runs `lerna publish` with conventional commits, deploys TypeDoc to `docs` branch
+- **OpenAPI Generator** (`openapi-generator.yml`): runs daily, creates a PR on `codegen/update-generator` when a new generator is released
+- **Release** (`release.yml`): manual workflow dispatch — runs `lerna publish` with conventional commits
+- **Documentation** (`docs.yml`): manual workflow dispatch, or automatically after a successful release — builds TypeDoc and deploys it to the `docs` branch
 - **PR validation** (`pr.yml`): enforces semantic PR titles
 
 ## Documentation
@@ -127,4 +129,4 @@ pnpm codegen schemas      # generate schemas only
 - Keep `README.md` files in sync with the codebase
 - Client READMEs are generated — to change them, edit `codegen/templates/README.md.mustache`
 - Schema README lists are generated — update after schema changes
-- TypeDoc is generated and deployed to the `docs` branch on release
+- TypeDoc is generated and deployed to the `docs` branch by the `Documentation` workflow — after each release, or on manual dispatch

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Modularized, fully-typed TypeScript SDK for the Amazon Selling Partner API (SP-A
 ## CI
 
 [![Codegen](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/codegen.yml/badge.svg)](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/codegen.yml)
+[![OpenAPI Generator](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/openapi-generator.yml/badge.svg)](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/openapi-generator.yml)
 [![Tests](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/tests.yml/badge.svg)](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/tests.yml)
 [![Release](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/release.yml/badge.svg)](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/release.yml)
+[![Documentation](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/docs.yml/badge.svg)](https://github.com/bizon/selling-partner-api-sdk/actions/workflows/docs.yml)
 
 ## Documentation
 


### PR DESCRIPTION
Splits documentation deployment out of the release workflow so it can be run on its own.

## Changes

- **New `Documentation` workflow** (`.github/workflows/docs.yml`) — the old `docs` job from `release.yml`, moved as-is:
  - `workflow_dispatch` so it can be triggered manually
  - `workflow_run` on `Release`, gated on `conclusion == 'success'` (equivalent to the previous `needs: release`)
  - `concurrency: docs`
- **`release.yml`** now only runs `lerna publish`.
- **Fix:** on the release-triggered path the checkout pins the tip of the default branch. The release event SHA predates the version-bump commit lerna pushes, so TypeDoc was documenting the pre-release versions.
- **README:** the CI section now lists every workflow (added `OpenAPI Generator` and `Documentation` badges); the PR title linter is left out.
- **CLAUDE.md:** CI/CD and Documentation sections updated to match.

## Note

`workflow_run` only fires from the copy of the workflow on the default branch, and manual dispatch only appears once the file is there — so both triggers become available after this is merged.