### PR TITLE
ci: deploy docs to Pages via Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,9 +8,11 @@ on:
 
 concurrency: docs
 
-# Checkout and deployment both use BOT_GITHUB_TOKEN_PUBLIC.
+# The Pages deployment authenticates through OIDC, hence id-token: write.
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   docs:
@@ -19,10 +21,13 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
       - uses: actions/checkout@v7
         with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
           # A release pushes version bumps after it starts, so the event SHA is
           # already stale: always document the tip of the default branch.
           ref: ${{ github.event_name == 'workflow_run' && github.event.repository.default_branch || github.ref }}
@@ -32,6 +37,8 @@ jobs:
         with:
           node-version-file: .node-version
 
+      - uses: actions/configure-pages@v6
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -40,12 +47,11 @@ jobs:
         env:
           NODE_OPTIONS: --max_old_space_size=6144
 
-      - name: Deploy documentation
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload documentation artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          branch: docs
-          folder: docs
-          token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
-          commit-message: "docs: update documentation"
-          git-config-name: ${{ secrets.BOT_NAME }}
-          git-config-email: ${{ secrets.BOT_EMAIL }}
+          path: docs
+
+      - name: Deploy documentation
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ pnpm codegen schemas      # generate schemas only
 - **Codegen** (`codegen.yml`): runs twice daily, creates PRs on `codegen/update-models` and `codegen/update-schemas` branches
 - **OpenAPI Generator** (`openapi-generator.yml`): runs daily, creates a PR on `codegen/update-generator` when a new generator is released
 - **Release** (`release.yml`): manual workflow dispatch — runs `lerna publish` with conventional commits
-- **Documentation** (`docs.yml`): manual workflow dispatch, or automatically after a successful release — builds TypeDoc and deploys it to the `docs` branch
+- **Documentation** (`docs.yml`): manual workflow dispatch, or automatically after a successful release — builds TypeDoc and deploys it to GitHub Pages via the official Pages actions
 - **PR validation** (`pr.yml`): enforces semantic PR titles
 
 ## Documentation
@@ -129,4 +129,4 @@ pnpm codegen schemas      # generate schemas only
 - Keep `README.md` files in sync with the codebase
 - Client READMEs are generated — to change them, edit `codegen/templates/README.md.mustache`
 - Schema README lists are generated — update after schema changes
-- TypeDoc is generated and deployed to the `docs` branch by the `Documentation` workflow — after each release, or on manual dispatch
+- TypeDoc is generated and deployed to GitHub Pages by the `Documentation` workflow — after each release, or on manual dispatch


### PR DESCRIPTION
Migrates the Documentation workflow from force-pushing the TypeDoc output to the `docs` branch (Pages in "deploy from a branch" mode) to deploying straight to GitHub Pages with the official actions:

- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5` with `path: docs`
- `actions/deploy-pages@v5`

The job gains `pages: write` + `id-token: write` permissions and a `github-pages` environment exposing the deployment URL. Build steps, the `concurrency: docs` group, the triggers and the `if:` condition are unchanged.

Checkout no longer needs elevated credentials — the deployment authenticates through OIDC and nothing pushes commits anymore.

The `docs` branch is intentionally left in place as a fallback until the new deployment is confirmed working.

## Ordering

The Pages source is managed in the `infra` repo (`github/repositories.tf`, `github_repository_pages`) and is being switched to `build_type = "workflow"`. `deploy-pages` will fail until that is applied, so this workflow cannot be green beforehand.

1. Merge this PR
2. Apply the infra change
3. Dispatch the Documentation workflow manually to verify