### PR TITLE
ci(codegen): commit root README in models PR

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Create or update clients pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: clients,pnpm-lock.yaml
+          add-paths: clients,pnpm-lock.yaml,README.md
           branch: codegen/update-models
           token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
           title: "feat(clients): update models as of ${{ steps.date.outputs.date }}"


### PR DESCRIPTION
## Problem

The codegen regenerates the clients list in the root `README.md` — `updateRootReadmeClientsList()` rewrites the block between the `<!-- codegen:clients:start -->` / `<!-- codegen:clients:end -->` markers, and is called at the end of `generateClients()`.

But the `Codegen: update models` job passes `add-paths: clients,pnpm-lock.yaml` to `peter-evans/create-pull-request`, which only stages the listed paths. The README *is* modified on the runner, then silently dropped — so new clients never show up in the README list.

That is why #1848 adds two new clients (`finances-invoices-api-2026-06-25`, `fulfillment-outbound-api-2026-07-04`) without touching the root README.

The allowlist dates back to #292, well before the generated clients list landed in #1775; it was never widened.

## Fix

Add `README.md` to `add-paths`.

The schemas job is unaffected — its `add-paths: packages/schemas` already covers the schema README.

## Follow-up

`codegen/update-models` needs to be regenerated **after** this merges, otherwise the same filter drops the README again.