### PR TITLE
fix(codegen): prune stale output and report changes

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -29,9 +29,15 @@ jobs:
       - name: Regenerate lockfile
         run: pnpm install --lockfile-only
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Read commit message
+        id: commit
+        run: |
+          {
+            echo "message<<COMMIT_MESSAGE_EOF"
+            cat codegen/clients-commit-message.txt
+            echo "COMMIT_MESSAGE_EOF"
+            echo "subject=$(head -1 codegen/clients-commit-message.txt)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create or update clients pull request
         uses: peter-evans/create-pull-request@v8
@@ -39,12 +45,9 @@ jobs:
           add-paths: clients,pnpm-lock.yaml,README.md
           branch: codegen/update-models
           token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
-          title: "feat(clients): update models as of ${{ steps.date.outputs.date }}"
-          commit-message: "feat(clients): update models as of ${{ steps.date.outputs.date }}"
-          body: |
-            This is an automated pull request that was generated due to changes detected in the [Amazon Selling Partner API models](https://github.com/amzn/selling-partner-api-models).
-
-            The branch associated with this PR will be automatically updated if other changes occur.
+          title: ${{ steps.commit.outputs.subject }}
+          commit-message: ${{ steps.commit.outputs.message }}
+          body-path: codegen/clients-pr-body.md
           delete-branch: true
           reviewers: tusbar
 
@@ -68,9 +71,15 @@ jobs:
       - name: Generate schemas
         run: pnpm codegen schemas
 
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+      - name: Read commit message
+        id: commit
+        run: |
+          {
+            echo "message<<COMMIT_MESSAGE_EOF"
+            cat codegen/schemas-commit-message.txt
+            echo "COMMIT_MESSAGE_EOF"
+            echo "subject=$(head -1 codegen/schemas-commit-message.txt)"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create or update schemas pull request
         uses: peter-evans/create-pull-request@v8
@@ -78,11 +87,8 @@ jobs:
           add-paths: packages/schemas
           branch: codegen/update-schemas
           token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
-          title: "feat(schemas): update schemas as of ${{ steps.date.outputs.date }}"
-          commit-message: "feat(schemas): update schemas as of ${{ steps.date.outputs.date }}"
-          body: |
-            This is an automated pull request that was generated due to changes detected in the [Amazon Selling Partner API models](https://github.com/amzn/selling-partner-api-models).
-
-            The branch associated with this PR will be automatically updated if other changes occur.
+          title: ${{ steps.commit.outputs.subject }}
+          commit-message: ${{ steps.commit.outputs.message }}
+          body-path: codegen/schemas-pr-body.md
           delete-branch: true
           reviewers: tusbar

--- a/codegen/.gitignore
+++ b/codegen/.gitignore
@@ -1,0 +1,6 @@
+# Pull request bodies and commit messages written by the codegen,
+# consumed by its workflow
+clients-pr-body.md
+schemas-pr-body.md
+clients-commit-message.txt
+schemas-commit-message.txt

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -12,13 +12,23 @@ import {remark} from 'remark'
 import remarkStrip from 'strip-markdown'
 import {type PackageJson} from 'type-fest'
 
+import {getChangedPaths} from './utils/git.js'
 import {logger} from './utils/logger.js'
 import {applyPatches} from './utils/patch.js'
+import {
+  buildSection,
+  formatDate,
+  writeCommitMessage,
+  writePullRequestBody,
+} from './utils/pull-request.js'
 import {renderTemplate} from './utils/render-template.js'
 import {runCommand} from './utils/run-command.js'
 import {replaceAllTags} from './utils/tags.js'
 
 const GRANTLESS_APIS = [{name: 'notifications-api-v1', scope: 'NOTIFICATIONS'}]
+
+const CLIENTS_PR_BODY_PATH = 'codegen/clients-pr-body.md'
+const CLIENTS_COMMIT_MESSAGE_PATH = 'codegen/clients-commit-message.txt'
 
 interface RateLimit {
   method: string
@@ -30,6 +40,11 @@ interface RateLimit {
 interface ClientInfo {
   packageName: string
   hasDeprecatedOperations: boolean
+}
+
+interface ClientsDiff {
+  added: string[]
+  removed: string[]
 }
 
 function buildUrlRegex(path: string) {
@@ -298,6 +313,72 @@ async function generateClientVersion(modelFilePath: string): Promise<ClientInfo>
   return {packageName, hasDeprecatedOperations: isDeprecated}
 }
 
+function diffClients(previousPackageNames: string[], clients: ClientInfo[]): ClientsDiff {
+  const previous = new Set(previousPackageNames)
+  const generated = new Set(clients.map((client) => client.packageName))
+
+  return {
+    added: [...generated].filter((packageName) => !previous.has(packageName)).toSorted(),
+    removed: previousPackageNames.filter((packageName) => !generated.has(packageName)).toSorted(),
+  }
+}
+
+// `generateClientVersion` cleans up inside each client, but nothing removes a
+// client whose model disappeared upstream – it would otherwise keep being
+// published, frozen at its last generated content.
+async function pruneStaleClients(packageNames: string[]) {
+  await Promise.all(
+    packageNames.map(async (packageName) => {
+      logger.info('removing stale client', {packageName})
+      await fs.rm(`clients/${packageName}`, {recursive: true})
+    }),
+  )
+}
+
+// Additions and removals both need a manual follow-up on npm – initializing the
+// package, or deprecating it – so they are called out in the pull request body
+// rather than left to be spotted in the diff.
+export async function writeClientsPullRequest({added, removed}: ClientsDiff) {
+  const changedPaths = await getChangedPaths('clients')
+  const reported = new Set([...added, ...removed])
+
+  // `clients/<packageName>/…`, minus the ones already reported as added or removed
+  const changed = [
+    ...new Set(
+      changedPaths
+        .map((path) => path.split('/', 2)[1])
+        .filter((packageName) => packageName !== undefined),
+    ),
+  ]
+    .filter((packageName) => !reported.has(packageName))
+    .toSorted()
+
+  const scoped = (packageNames: string[]) =>
+    packageNames.map((packageName) => `@sp-api-sdk/${packageName}`)
+
+  await writePullRequestBody(CLIENTS_PR_BODY_PATH, [
+    ...buildSection(
+      'New clients',
+      'These packages do not exist on npm yet – initialize them before the next release:',
+      scoped(added),
+    ),
+    ...buildSection(
+      'Removed clients',
+      'Amazon no longer publishes a model for these and they were deleted – deprecate them on npm:',
+      scoped(removed),
+    ),
+    ...buildSection('Updated clients', 'These packages changed:', scoped(changed)),
+  ])
+
+  await writeCommitMessage(
+    CLIENTS_COMMIT_MESSAGE_PATH,
+    `feat(clients): update models as of ${formatDate()}`,
+    removed.length > 0
+      ? `Amazon no longer publishes a model for ${scoped(removed).join(', ')}, so ${removed.length > 1 ? 'those packages were' : 'that package was'} removed from the SDK.`
+      : undefined,
+  )
+}
+
 const CLIENTS_LIST_START = '<!-- codegen:clients:start -->'
 const CLIENTS_LIST_END = '<!-- codegen:clients:end -->'
 
@@ -333,13 +414,23 @@ async function updateRootReadmeClientsList(clients: ClientInfo[]) {
 }
 
 export async function generateClients() {
-  // Pre-download the JAR to avoid race conditions when running in parallel
-  await runCommand('codegen/node_modules/.bin/openapi-generator-cli version')
-
   const modelFilePaths = await globby('*/*.json', {
     onlyFiles: true,
     cwd: 'selling-partner-api-models/models',
   })
+
+  // Guards the pruning below: were upstream to move or rename its models
+  // directory, an empty result would otherwise read as "every model was
+  // removed" and delete every client package in the repository
+  if (modelFilePaths.length === 0) {
+    throw new Error('No models found in selling-partner-api-models/models')
+  }
+
+  // Pre-download the JAR to avoid race conditions when running in parallel
+  await runCommand('codegen/node_modules/.bin/openapi-generator-cli version')
+
+  // Snapshot before generating anything, to report what this run added or removed
+  const previousPackageNames = await globby('*', {onlyDirectories: true, cwd: 'clients'})
 
   const clients = await pMap(
     modelFilePaths,
@@ -349,5 +440,10 @@ export async function generateClients() {
     },
   )
 
+  const diff = diffClients(previousPackageNames, clients)
+
+  await pruneStaleClients(diff.removed)
   await updateRootReadmeClientsList(clients)
+
+  return diff
 }

--- a/codegen/generate-schemas.ts
+++ b/codegen/generate-schemas.ts
@@ -7,7 +7,17 @@ import {globby} from 'globby'
 import {kebabCase} from 'lodash-es'
 import pMap from 'p-map'
 
+import {getChangedPaths} from './utils/git.js'
 import {logger} from './utils/logger.js'
+import {
+  buildSection,
+  formatDate,
+  writeCommitMessage,
+  writePullRequestBody,
+} from './utils/pull-request.js'
+
+const SCHEMAS_PR_BODY_PATH = 'codegen/schemas-pr-body.md'
+const SCHEMAS_COMMIT_MESSAGE_PATH = 'codegen/schemas-commit-message.txt'
 
 interface SchemaFile {
   schemaName: string
@@ -15,10 +25,21 @@ interface SchemaFile {
   fileName: string
 }
 
+interface DirectoryResult {
+  directoryName: string
+  added: string[]
+  removed: string[]
+}
+
+interface SchemasDiff {
+  added: string[]
+  removed: string[]
+}
+
 async function generateSchema(
   schemaFilePath: string,
   outputDirectory: string,
-): Promise<SchemaFile | undefined> {
+): Promise<SchemaFile> {
   const schemaType = basename(outputDirectory)
   const {name: parsedName} = parsePath(schemaFilePath)
   const startedAt = Date.now()
@@ -66,9 +87,38 @@ async function generateSchema(
       schemaName,
       schemaTypeName,
     }
-  } catch {
-    logger.error('failed generating', {schemaName: schemaTypeName, schemaType})
+  } catch (error) {
+    // Never swallow this. A schema that fails to generate would silently drop
+    // out of the directory index – a breaking change for consumers, and one
+    // that is indistinguishable from a genuine upstream removal.
+    throw new Error(`Failed generating schema ${schemaTypeName} (${schemaType})`, {cause: error})
   }
+}
+
+// Every generated schema in a directory, excluding the barrel file
+async function listSchemaFileNames(outputDirectory: string) {
+  const fileNames = await globby('*.ts', {onlyFiles: true, cwd: outputDirectory})
+
+  return fileNames.filter((fileName) => fileName !== 'index.ts')
+}
+
+// Reported as `<schemaType>/<fileName>`, which is what the diff shows
+function toSchemaName(directoryName: string, fileName: string) {
+  return `${directoryName}/${basename(fileName, '.ts')}`
+}
+
+// Remove generated schemas that no longer exist upstream. The generator only
+// ever writes files, so without this a schema removed by Amazon would drop out
+// of the index while its file lingered in the tree forever.
+async function pruneStaleSchemas(staleFileNames: string[], outputDirectory: string) {
+  const schemaType = basename(outputDirectory)
+
+  await Promise.all(
+    staleFileNames.map(async (fileName) => {
+      logger.info('removing stale schema', {schemaName: fileName, schemaType})
+      await fs.rm(`${outputDirectory}/${fileName}`)
+    }),
+  )
 }
 
 async function generateDirectoryIndex(schemas: SchemaFile[], outputDirectory: string) {
@@ -82,7 +132,10 @@ async function generateDirectoryIndex(schemas: SchemaFile[], outputDirectory: st
   await fs.writeFile(`${outputDirectory}/index.ts`, body)
 }
 
-async function generateDirectorySchemas(schemaDirectory: string, directoryName: string) {
+async function generateDirectorySchemas(
+  schemaDirectory: string,
+  directoryName: string,
+): Promise<DirectoryResult | undefined> {
   const schemaFilePaths = await globby('*.json', {
     onlyFiles: true,
     cwd: schemaDirectory,
@@ -90,11 +143,14 @@ async function generateDirectorySchemas(schemaDirectory: string, directoryName: 
   })
 
   if (schemaFilePaths.length === 0) {
-    return 0
+    return undefined
   }
 
   const outputDirectory = `packages/schemas/src/${directoryName}`
   await mkdir(outputDirectory, {recursive: true})
+
+  // Snapshot before generating, to report what this run added or removed
+  const previousFileNames = await listSchemaFileNames(outputDirectory)
 
   const schemas = await pMap(
     schemaFilePaths,
@@ -104,12 +160,43 @@ async function generateDirectorySchemas(schemaDirectory: string, directoryName: 
     },
   )
 
-  await generateDirectoryIndex(
-    schemas.filter((schema): schema is NonNullable<typeof schema> => schema !== undefined),
-    outputDirectory,
+  const previous = new Set(previousFileNames)
+  const generatedFileNames = new Set(schemas.map((schema) => `${schema.fileName}.ts`))
+  const removed = previousFileNames.filter((fileName) => !generatedFileNames.has(fileName))
+
+  await pruneStaleSchemas(removed, outputDirectory)
+  await generateDirectoryIndex(schemas, outputDirectory)
+
+  return {
+    directoryName,
+    added: [...generatedFileNames]
+      .filter((fileName) => !previous.has(fileName))
+      .map((fileName) => toSchemaName(directoryName, fileName)),
+    removed: removed.map((fileName) => toSchemaName(directoryName, fileName)),
+  }
+}
+
+// Same as `pruneStaleSchemas`, one level up: drop directories for schema types
+// that upstream no longer publishes at all. Returns the schemas they held, so
+// that they are reported as removed rather than vanishing silently.
+async function pruneStaleDirectories(directoryNames: string[], outputDirectory: string) {
+  const generatedDirectoryNames = new Set(directoryNames)
+  const existingDirectoryNames = await globby('*', {onlyDirectories: true, cwd: outputDirectory})
+
+  const removed = await Promise.all(
+    existingDirectoryNames
+      .filter((directoryName) => !generatedDirectoryNames.has(directoryName))
+      .map(async (directoryName) => {
+        const fileNames = await listSchemaFileNames(`${outputDirectory}/${directoryName}`)
+
+        logger.info(`removing stale schema directory ${directoryName}`)
+        await fs.rm(`${outputDirectory}/${directoryName}`, {recursive: true})
+
+        return fileNames.map((fileName) => toSchemaName(directoryName, fileName))
+      }),
   )
 
-  return schemas.length
+  return removed.flat()
 }
 
 async function generateIndex(directoryNames: string[], outputDirectory: string) {
@@ -135,18 +222,74 @@ export async function generateSchemas() {
     cwd: prefix,
   })
 
+  // Guards the pruning below, as an empty result would otherwise read as "every
+  // schema type was removed". A directory holding no schemas is normal though –
+  // upstream `data-kiosk` has none – so only the total is checked here.
+  if (schemaDirectories.length === 0) {
+    throw new Error(`No schema directories found in ${prefix}`)
+  }
+
   const results = await pMap(
     schemaDirectories,
-    async (schemaDirectory) => {
-      const length = await generateDirectorySchemas(`${prefix}/${schemaDirectory}`, schemaDirectory)
-      return length > 0 ? schemaDirectory : undefined
-    },
+    async (schemaDirectory) =>
+      generateDirectorySchemas(`${prefix}/${schemaDirectory}`, schemaDirectory),
     {concurrency: os.cpus().length},
   )
 
-  const generatedDirectories = results.filter(
-    (directory): directory is string => directory !== undefined,
-  )
+  const directories = results.filter((result) => result !== undefined)
+  const generatedDirectories = directories.map((directory) => directory.directoryName)
 
+  const removedDirectorySchemas = await pruneStaleDirectories(
+    generatedDirectories,
+    'packages/schemas/src',
+  )
   await generateIndex(generatedDirectories, 'packages/schemas/src')
+
+  return {
+    added: directories.flatMap((directory) => directory.added).toSorted(),
+    removed: [
+      ...directories.flatMap((directory) => directory.removed),
+      ...removedDirectorySchemas,
+    ].toSorted(),
+  }
+}
+
+// Removals drop exports from `@sp-api-sdk/schemas` and so are breaking for
+// consumers – they are called out rather than left to be spotted in the diff.
+export async function writeSchemasPullRequest({added, removed}: SchemasDiff) {
+  const changedPaths = await getChangedPaths('packages/schemas/src')
+  const reported = new Set([...added, ...removed])
+
+  // `packages/schemas/src/<directory>/<file>.ts`, barrel files aside
+  const changed = changedPaths
+    .map((path) => {
+      const [directoryName, fileName] = path.split('/').slice(3)
+
+      if (directoryName === undefined || fileName === undefined || fileName === 'index.ts') {
+        return undefined
+      }
+
+      return toSchemaName(directoryName, fileName)
+    })
+    .filter((schemaName) => schemaName !== undefined)
+    .filter((schemaName) => !reported.has(schemaName))
+    .toSorted()
+
+  await writePullRequestBody(SCHEMAS_PR_BODY_PATH, [
+    ...buildSection('New schemas', 'These schemas are newly exported:', added),
+    ...buildSection(
+      'Removed schemas',
+      'Amazon no longer publishes these and they were deleted – dropping their exports is a breaking change:',
+      removed,
+    ),
+    ...buildSection('Updated schemas', 'These schemas changed:', changed),
+  ])
+
+  await writeCommitMessage(
+    SCHEMAS_COMMIT_MESSAGE_PATH,
+    `feat(schemas): update schemas as of ${formatDate()}`,
+    removed.length > 0
+      ? `Amazon no longer publishes ${removed.join(', ')}, so ${removed.length > 1 ? 'those schemas and their exports were' : 'that schema and its export was'} removed from \`@sp-api-sdk/schemas\`.`
+      : undefined,
+  )
 }

--- a/codegen/generate.ts
+++ b/codegen/generate.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises'
 import process from 'node:process'
 
-import {generateClients} from './generate-clients.js'
-import {generateSchemas} from './generate-schemas.js'
+import {generateClients, writeClientsPullRequest} from './generate-clients.js'
+import {generateSchemas, writeSchemasPullRequest} from './generate-schemas.js'
 import {runCommand} from './utils/run-command.js'
 
 type Generator = 'clients' | 'schemas'
@@ -16,17 +16,22 @@ if (generators.size === 0) {
 await fs.rm('selling-partner-api-models', {recursive: true, force: true})
 await runCommand('git clone https://github.com/amzn/selling-partner-api-models')
 
+// The pull request body and commit message report what changed against HEAD, so
+// they are written last – after the lint pass has settled the final contents of
+// every file
 if (generators.has('clients')) {
   console.info('Generating clients…')
-  await generateClients()
+  const diff = await generateClients()
   await runCommand('pnpm install --no-frozen-lockfile')
   await runCommand('pnpm --filter "./clients/**" xo --fix')
+  await writeClientsPullRequest(diff)
 }
 
 if (generators.has('schemas')) {
   console.info('Generating schemas…')
-  await generateSchemas()
+  const diff = await generateSchemas()
   await runCommand('pnpm --filter "./packages/schemas" xo --fix')
+  await writeSchemasPullRequest(diff)
 }
 
 await fs.rm('selling-partner-api-models', {recursive: true})

--- a/codegen/utils/git.ts
+++ b/codegen/utils/git.ts
@@ -1,0 +1,15 @@
+import {runCommand} from './run-command.js'
+
+// Paths under `pathspec` that differ from HEAD – modified, deleted or untracked.
+// Renames are disabled so that every entry is a plain `XY <path>` line.
+export async function getChangedPaths(pathspec: string) {
+  const {stdout} = await runCommand(
+    `git status --porcelain=v1 --untracked-files=all --no-renames -- ${pathspec}`,
+    {quiet: true},
+  )
+
+  return stdout
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+}

--- a/codegen/utils/pull-request.ts
+++ b/codegen/utils/pull-request.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises'
+
+const INTRO = [
+  'This is an automated pull request that was generated due to changes detected in the [Amazon Selling Partner API models](https://github.com/amzn/selling-partner-api-models).',
+  'The branch associated with this PR will be automatically updated if other changes occur.',
+]
+
+const BODY_WIDTH = 72
+
+export function formatDate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function wrap(text: string) {
+  const lines: string[] = []
+  let line = ''
+
+  for (const word of text.split(' ')) {
+    if (line.length === 0) {
+      line = word
+    } else if (`${line} ${word}`.length <= BODY_WIDTH) {
+      line += ` ${word}`
+    } else {
+      lines.push(line)
+      line = word
+    }
+  }
+
+  if (line.length > 0) {
+    lines.push(line)
+  }
+
+  return lines.join('\n')
+}
+
+export function buildSection(heading: string, description: string, items: string[]) {
+  if (items.length === 0) {
+    return []
+  }
+
+  return [`### ${heading}`, description, items.map((item) => `- \`${item}\``).join('\n')]
+}
+
+// Consumed by the codegen workflow, which hands the file to `create-pull-request`
+// via `body-path`. Always write it, so that re-running against an existing branch
+// cannot leave a stale body behind.
+export async function writePullRequestBody(path: string, sections: string[] = []) {
+  await fs.writeFile(path, `${[...INTRO, ...sections].join('\n\n')}\n`)
+}
+
+// The repository only allows squash merges, and squashes take their body from
+// the branch commit messages rather than the pull request body – so a removal
+// has to be flagged here for lerna to cut the release as a major.
+export async function writeCommitMessage(path: string, subject: string, breakingChange?: string) {
+  const message =
+    breakingChange === undefined
+      ? subject
+      : `${subject}\n\n${wrap(`BREAKING CHANGE: ${breakingChange}`)}`
+
+  await fs.writeFile(path, `${message}\n`)
+}


### PR DESCRIPTION
## Why

The codegen only ever wrote files – it never removed them. When Amazon drops a schema or a model, it falls out of the generated barrel file but its `.ts` stays in the tree forever.

This is not hypothetical: `notifications/mfn-order-status-change-notification` and `notifications/order-status-change-notification` have been orphaned since the schemas package was created (#1316), and `git log --diff-filter=D` shows no commit has ever deleted a generated schema file. Client packages were only ever removed by hand (#1563). #1856 is the same thing happening again with the two tax-invoice schemas.

## What changed

**Pruning.** Generated schemas, schema directories and client packages that no longer exist upstream are now removed. Each generator first checks that its upstream glob returned anything at all: an empty result (upstream moving or renaming a directory) would otherwise read as "everything was removed" and delete every package in the repo. The check is deliberately on the total only, because a directory holding no schemas is normal – upstream `data-kiosk` has none.

**Generation failures are no longer swallowed.** A schema that failed to generate was logged and dropped from the index, producing a diff byte-identical to a genuine upstream removal, so a silent breaking change was indistinguishable from an intended one. It now throws and fails the job.

**The pull request body and commit message are built by the script**, not the workflow, and list the clients and schemas that were added, removed and updated. Additions and removals each need a manual follow-up on npm (initializing the package, or deprecating it), so they are called out explicitly instead of being left to spot in the diff.

**Removals add a `BREAKING CHANGE:` footer to the commit message.** This repo squash-merges with `squash_merge_commit_message: COMMIT_MESSAGES`, so the squash body comes from the branch commit message rather than the PR body. Putting the footer anywhere else would have had no effect on the release.

Example body a run with a removal now produces:

> ### Removed schemas
> Amazon no longer publishes these and they were deleted – dropping their exports is a breaking change:
> - `notifications/tax-invoice-export-status-change`

with the matching commit message:

```
feat(schemas): update schemas as of 2026-07-31

BREAKING CHANGE: Amazon no longer publishes
notifications/tax-invoice-export-status-change, so that schema and
its export was removed from `@sp-api-sdk/schemas`.
```

## Verification

`pnpm xo`, `pnpm check:ts` (71/71) and `pnpm test` (4/4) pass. Beyond that:

- Ran the reporters against real git state with files deliberately dirtied; they correctly picked up the changed client and schema and omitted empty sections.
- Ran both generators with no upstream checkout: the guards threw and nothing was deleted. Without them that path deletes all 65 client packages and all three schema directories.
- Simulated the workflow's `$GITHUB_OUTPUT` step and confirmed the multi-line heredoc form is valid and the delimiter cannot collide.

## Note

Because a missing model now prunes its package, an unattended run can propose deleting a published client. That arrives as a reviewed PR with an explicit "Removed clients / deprecate them on npm" section, which is the intended safety net. I did not add a ratio-based threshold, as it would be heuristic and would eventually block a legitimate mass removal.