### PR TITLE
feat(codegen): generate the schemas README list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,5 +128,5 @@ pnpm codegen schemas      # generate schemas only
 
 - Keep `README.md` files in sync with the codebase
 - Client READMEs are generated — to change them, edit `codegen/templates/README.md.mustache`
-- Schema README lists are generated — update after schema changes
+- The client list in `README.md` and the schema list in `packages/schemas/README.md` are rewritten by codegen between their `<!-- codegen:clients:… -->` / `<!-- codegen:schemas:… -->` markers — never edit them by hand, and keep the markers in place
 - TypeDoc is generated and deployed to GitHub Pages by the `Documentation` workflow — after each release, or on manual dispatch

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -62,6 +62,18 @@ For each schema:
 1. **Read** the JSON schema and remove the `$schema` field
 2. **Generate** a TypeScript file exporting the schema as a const and a derived type using `json-schema-to-ts`
 3. **Generate** barrel index files for each schema directory and a root index
+4. **Update** the schema list in `packages/schemas/README.md`
+
+### Generated README lists
+
+Both generators rewrite a list inside a hand-written README, delimited by HTML comment markers:
+
+| README                       | Markers                      | Content                                            |
+| ---------------------------- | ---------------------------- | -------------------------------------------------- |
+| `README.md`                  | `<!-- codegen:clients:… -->` | One entry per client package                       |
+| `packages/schemas/README.md` | `<!-- codegen:schemas:… -->` | One section per schema directory, with its exports |
+
+Anything between the markers is replaced on every run; the surrounding prose is left alone. A missing marker fails the run rather than silently leaving a stale list behind.
 
 ## Patches
 

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -21,6 +21,7 @@ import {
   writeCommitMessage,
   writePullRequestBody,
 } from './utils/pull-request.js'
+import {replaceReadmeSection} from './utils/readme.js'
 import {renderTemplate} from './utils/render-template.js'
 import {runCommand} from './utils/run-command.js'
 import {replaceAllTags} from './utils/tags.js'
@@ -29,6 +30,7 @@ const GRANTLESS_APIS = [{name: 'notifications-api-v1', scope: 'NOTIFICATIONS'}]
 
 const CLIENTS_PR_BODY_PATH = 'codegen/clients-pr-body.md'
 const CLIENTS_COMMIT_MESSAGE_PATH = 'codegen/clients-commit-message.txt'
+const ROOT_README_PATH = 'README.md'
 
 interface RateLimit {
   method: string
@@ -379,13 +381,7 @@ export async function writeClientsPullRequest({added, removed}: ClientsDiff) {
   )
 }
 
-const CLIENTS_LIST_START = '<!-- codegen:clients:start -->'
-const CLIENTS_LIST_END = '<!-- codegen:clients:end -->'
-
 async function updateRootReadmeClientsList(clients: ClientInfo[]) {
-  const readmePath = 'README.md'
-  const readme = await fs.readFile(readmePath, 'utf8')
-
   const sorted = clients.toSorted((a, b) => a.packageName.localeCompare(b.packageName))
   const list = sorted
     .map((client) => {
@@ -395,22 +391,7 @@ async function updateRootReadmeClientsList(clients: ClientInfo[]) {
     })
     .join('\n')
 
-  const pattern = new RegExp(
-    `${RegExp.escape(CLIENTS_LIST_START)}.*?${RegExp.escape(CLIENTS_LIST_END)}`,
-    'sv',
-  )
-
-  if (!pattern.test(readme)) {
-    throw new Error(
-      `Could not find clients list markers (${CLIENTS_LIST_START} / ${CLIENTS_LIST_END}) in ${readmePath}`,
-    )
-  }
-
-  const replacement = `${CLIENTS_LIST_START}\n\n${list}\n\n${CLIENTS_LIST_END}`
-  await fs.writeFile(
-    readmePath,
-    readme.replace(pattern, () => replacement),
-  )
+  await replaceReadmeSection(ROOT_README_PATH, 'clients', list)
 }
 
 export async function generateClients() {

--- a/codegen/generate-schemas.ts
+++ b/codegen/generate-schemas.ts
@@ -15,9 +15,11 @@ import {
   writeCommitMessage,
   writePullRequestBody,
 } from './utils/pull-request.js'
+import {replaceReadmeSection} from './utils/readme.js'
 
 const SCHEMAS_PR_BODY_PATH = 'codegen/schemas-pr-body.md'
 const SCHEMAS_COMMIT_MESSAGE_PATH = 'codegen/schemas-commit-message.txt'
+const SCHEMAS_README_PATH = 'packages/schemas/README.md'
 
 interface SchemaFile {
   schemaName: string
@@ -27,6 +29,7 @@ interface SchemaFile {
 
 interface DirectoryResult {
   directoryName: string
+  schemas: SchemaFile[]
   added: string[]
   removed: string[]
 }
@@ -169,6 +172,7 @@ async function generateDirectorySchemas(
 
   return {
     directoryName,
+    schemas,
     added: [...generatedFileNames]
       .filter((fileName) => !previous.has(fileName))
       .map((fileName) => toSchemaName(directoryName, fileName)),
@@ -199,19 +203,42 @@ async function pruneStaleDirectories(directoryNames: string[], outputDirectory: 
   return removed.flat()
 }
 
+// The namespace each directory is exported under from the package root, e.g.
+// `Reports` in `import {Reports} from '@sp-api-sdk/schemas'`
+function toNamespaceName(directoryName: string) {
+  return camelCase(directoryName, {
+    pascalCase: true,
+    locale: false,
+  })
+}
+
 async function generateIndex(directoryNames: string[], outputDirectory: string) {
   const body = directoryNames
-    .map((directoryName) => {
-      const schemaType = camelCase(directoryName, {
-        pascalCase: true,
-        locale: false,
-      })
-
-      return `export * as ${schemaType} from './${directoryName}/index.js'`
-    })
+    .map(
+      (directoryName) =>
+        `export * as ${toNamespaceName(directoryName)} from './${directoryName}/index.js'`,
+    )
     .join('\n')
 
   await fs.writeFile(`${outputDirectory}/index.ts`, body)
+}
+
+// The schema list in the package README is generated the same way the client
+// list in the root README is – it is far too long to keep in sync by hand.
+async function updateSchemasReadme(directories: DirectoryResult[]) {
+  const sections = directories
+    .toSorted((a, b) => a.directoryName.localeCompare(b.directoryName))
+    .map(({directoryName, schemas}) => {
+      const heading = `### ${toNamespaceName(directoryName)} (${schemas.length} ${schemas.length === 1 ? 'schema' : 'schemas'})`
+      const list = schemas
+        .toSorted((a, b) => a.schemaName.localeCompare(b.schemaName))
+        .map((schema) => `- \`${schema.schemaName}\` / \`${schema.schemaTypeName}\``)
+        .join('\n')
+
+      return `${heading}\n\n${list}`
+    })
+
+  await replaceReadmeSection(SCHEMAS_README_PATH, 'schemas', sections.join('\n\n'))
 }
 
 export async function generateSchemas() {
@@ -244,6 +271,7 @@ export async function generateSchemas() {
     'packages/schemas/src',
   )
   await generateIndex(generatedDirectories, 'packages/schemas/src')
+  await updateSchemasReadme(directories)
 
   return {
     added: directories.flatMap((directory) => directory.added).toSorted(),

--- a/codegen/utils/readme.ts
+++ b/codegen/utils/readme.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises'
+
+// The generated lists live inside hand-written READMEs, delimited by HTML
+// comments so the surrounding prose stays editable. A missing marker throws
+// rather than silently leaving a stale list behind.
+export async function replaceReadmeSection(readmePath: string, name: string, content: string) {
+  const readme = await fs.readFile(readmePath, 'utf8')
+
+  const start = `<!-- codegen:${name}:start -->`
+  const end = `<!-- codegen:${name}:end -->`
+
+  const pattern = new RegExp(`${RegExp.escape(start)}.*?${RegExp.escape(end)}`, 'sv')
+
+  if (!pattern.test(readme)) {
+    throw new Error(`Could not find ${name} markers (${start} / ${end}) in ${readmePath}`)
+  }
+
+  const replacement = `${start}\n\n${content}\n\n${end}`
+
+  await fs.writeFile(
+    readmePath,
+    readme.replace(pattern, () => replacement),
+  )
+}

--- a/packages/schemas/README.md
+++ b/packages/schemas/README.md
@@ -46,11 +46,13 @@ const report = (await getVendorInventoryReportData()) as Reports.VendorInventory
 
 ## Available Schemas
 
+<!-- codegen:schemas:start -->
+
 ### Feeds (3 schemas)
 
-- `listingsFeedSchemaV2` / `ListingsFeedSchemaV2`
 - `listingsFeedMessageSchemaV2` / `ListingsFeedMessageSchemaV2`
 - `listingsFeedProcessingReportSchemaV2` / `ListingsFeedProcessingReportSchemaV2`
+- `listingsFeedSchemaV2` / `ListingsFeedSchemaV2`
 
 ### Notifications (22 schemas)
 
@@ -61,8 +63,8 @@ const report = (await getVendorInventoryReportData()) as Reports.VendorInventory
 - `detailPageTrafficEventNotification` / `DetailPageTrafficEventNotification`
 - `fbaInventoryAvailabilityChangeNotification` / `FBAInventoryAvailabilityChangeNotification`
 - `fbaOutboundShipmentStatusNotification` / `FBAOutboundShipmentStatusNotification`
-- `feePromotionNotification` / `FeePromotionNotification`
 - `feedProcessingFinishedNotification` / `FeedProcessingFinishedNotification`
+- `feePromotionNotification` / `FeePromotionNotification`
 - `fulfillmentOrderStatusNotification` / `FulfillmentOrderStatusNotification`
 - `itemInventoryEventChangeNotification` / `ItemInventoryEventChangeNotification`
 - `itemProductTypeChangeNotification` / `ItemProductTypeChangeNotification`
@@ -101,6 +103,8 @@ const report = (await getVendorInventoryReportData()) as Reports.VendorInventory
 - `vendorRealTimeTrafficReport` / `VendorRealTimeTrafficReport`
 - `vendorSalesReport` / `VendorSalesReport`
 - `vendorTrafficReport` / `VendorTrafficReport`
+
+<!-- codegen:schemas:end -->
 
 ## License
 


### PR DESCRIPTION
## What

The schema list in `packages/schemas/README.md` was maintained by hand, and nothing kept it in sync with the generated exports. It now lives between `<!-- codegen:schemas:start -->` / `<!-- codegen:schemas:end -->` markers and is rewritten on every `pnpm codegen schemas`, exactly like the client list in the root README.

- `codegen/utils/readme.ts` (new) — `replaceReadmeSection()`, extracted from the clients generator: swaps everything between the markers, throwing if they are missing rather than silently leaving a stale list behind.
- `codegen/generate-clients.ts` — `updateRootReadmeClientsList` now uses the shared helper instead of inlining the regex.
- `codegen/generate-schemas.ts` — new `updateSchemasReadme`, called from `generateSchemas` right after `generateIndex`. `DirectoryResult` carries the `SchemaFile[]` it generated, and the `Feeds` / `Notifications` / `Reports` headings reuse the same `toNamespaceName` helper as the root barrel, so a heading always matches the namespace consumers actually import.
- `packages/schemas/README.md` — markers added, list regenerated.

No workflow change needed: `add-paths: packages/schemas` in `codegen.yml` already covers the README.

## Why the list looked stale

The schema *set* was in fact correct (3 / 22 / 22, nothing missing or extra). What was off was the ordering — `listingsFeedSchemaV2` was listed first under Feeds, and `feePromotionNotification` came before `feedProcessingFinishedNotification`. Both are now sorted deterministically. The list happened to be accurate today, but nothing prevented it from drifting; that is what this fixes.

## Testing

- `pnpm codegen schemas` run end-to-end, README regenerated as expected
- `pnpm check:ts` (71/71) and `pnpm test` pass, `xo` clean on `codegen/`