### PR TITLE
fix(codegen): report unreadable rate limit tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ internal/
 codegen/                    # Code generation tooling (private, not published)
   templates/                # Mustache templates for generated clients
   patches/                  # JSON Patch files for fixing invalid OpenAPI specs
+  utils/                    # Codegen helpers (rate limits, patches, git)
+  tests/                    # Jest tests, mirroring utils/
 ```
 
 ### What is generated vs hand-written

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -20,6 +20,8 @@ pnpm codegen schemas      # generate schemas only
 
 The command clones Amazon's [selling-partner-api-models](https://github.com/amzn/selling-partner-api-models) repository, generates the code, runs lint auto-fix, then cleans up.
 
+The pure parts of the pipeline are covered by tests in `tests/`, run with `pnpm test` from the repository root or `pnpm --filter @sp-api-sdk/generator test`.
+
 ## How it works
 
 ### Client generation
@@ -30,11 +32,15 @@ The pipeline for each model:
 
 1. **Read & normalize** the OpenAPI spec — fix `doc:` markdown URLs, apply JSON patches, and replace operation tags with a consistent client name
 2. **Run OpenAPI Generator** (`typescript-axios` generator) to produce the raw API model (types, endpoints, configuration)
-3. **Extract rate limits** from operation descriptions using regex, embedding them as a `RateLimit[]` constant in each client
+3. **Extract rate limits** from the usage plan table in each operation description, embedding them as a `RateLimit[]` constant in each client
 4. **Render Mustache templates** for the client wrapper class, `package.json`, tsconfig files, README, and TypeDoc config
 5. **Clean up** generated files, keeping only `api/`, `models/`, and infrastructure files
 
 All models are processed in parallel (one per CPU core) using `p-map`. The OpenAPI Generator JAR is pre-downloaded to prevent race conditions.
+
+#### Missing rate limits
+
+Amazon documents no usage plan at all for a number of operations – those are reported as a per-client count and leave the client without a rate limit for that endpoint. An operation that _does_ carry a usage plan table the extraction cannot read is logged as a warning naming the method and path: either Amazon publishes placeholder values, or the table format changed and the regex needs updating. Watch for those warnings in the codegen workflow – they are the only signal that a rate limit silently disappeared.
 
 #### Client wrapper pattern
 

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -5,7 +5,7 @@ import {basename, parse as parsePath} from 'node:path'
 import camelCase from 'camelcase'
 import {globby} from 'globby'
 import jsonfile from 'jsonfile'
-import {kebabCase, reduce} from 'lodash-es'
+import {kebabCase} from 'lodash-es'
 import {OpenAPIV3} from 'openapi-types'
 import pMap from 'p-map'
 import {remark} from 'remark'
@@ -21,6 +21,7 @@ import {
   writeCommitMessage,
   writePullRequestBody,
 } from './utils/pull-request.js'
+import {extractRateLimits} from './utils/rate-limits.js'
 import {replaceReadmeSection} from './utils/readme.js'
 import {renderTemplate} from './utils/render-template.js'
 import {runCommand} from './utils/run-command.js'
@@ -32,13 +33,6 @@ const CLIENTS_PR_BODY_PATH = 'codegen/clients-pr-body.md'
 const CLIENTS_COMMIT_MESSAGE_PATH = 'codegen/clients-commit-message.txt'
 const ROOT_README_PATH = 'README.md'
 
-interface RateLimit {
-  method: string
-  rate: number
-  burst: number
-  urlRegex: string
-}
-
 interface ClientInfo {
   packageName: string
   hasDeprecatedOperations: boolean
@@ -47,15 +41,6 @@ interface ClientInfo {
 interface ClientsDiff {
   added: string[]
   removed: string[]
-}
-
-function buildUrlRegex(path: string) {
-  const source = path
-    .split(/\{[^\{\}]+\}/v)
-    .map((literal) => RegExp.escape(literal))
-    .join(String.raw`[^\/]*`)
-
-  return `/^${source}$/v`
 }
 
 function hasDeprecatedOperations(document: OpenAPIV3.Document): boolean {
@@ -202,50 +187,7 @@ async function generateClientVersion(modelFilePath: string): Promise<ClientInfo>
     }),
   )
 
-  const rateLimits = reduce(
-    document.paths,
-    (accumulator: RateLimit[], pathItem, key) => {
-      if (!pathItem) {
-        return accumulator
-      }
-
-      for (const method of Object.keys(pathItem) as OpenAPIV3.HttpMethods[]) {
-        const {description} = pathItem[method] as OpenAPIV3.PathItemObject
-
-        if (description) {
-          const result =
-            /Rate \(requests per second\) \| Burst \|\n(?:\| -{4} )+\|\n(?:\|Default)?\| (?<rate>(?:\d*\.)?\d+) \| (?<burst>(?:\d*\.)?\d+) \|/v.exec(
-              description,
-            )
-
-          if (result?.groups) {
-            const rateLimit = {
-              method,
-              rate: Number(result.groups.rate),
-              burst: Number(result.groups.burst),
-              urlRegex: buildUrlRegex(key),
-            }
-
-            if (Number.isNaN(rateLimit.rate) || Number.isNaN(rateLimit.burst)) {
-              logger.warn(
-                `Warning: invalid rate limits: ${result.groups.rate} / ${result.groups.burst}`,
-                {packageName},
-              )
-            }
-
-            accumulator.push(rateLimit)
-          } else {
-            logger.warn(`Warning: no rate limiting found for ${packageName}`, {
-              packageName,
-            })
-          }
-        }
-      }
-
-      return accumulator
-    },
-    [],
-  )
+  const rateLimits = extractRateLimits(document, packageName)
 
   await fs.writeFile(
     `${clientDirectoryPath}/tsconfig.json`,

--- a/codegen/jest.config.ts
+++ b/codegen/jest.config.ts
@@ -1,0 +1,9 @@
+import setup from '@sp-api-sdk/jest/config'
+
+export default async function config() {
+  return {
+    ...(await setup()),
+    // The codegen has no `src` directory, its sources sit at the root
+    collectCoverageFrom: ['utils/*.ts'],
+  }
+}

--- a/codegen/package.json
+++ b/codegen/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "xo": "xo --cwd=.. codegen",
-    "check:ts": "tsc --noEmit"
+    "check:ts": "tsc --noEmit",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "engines": {
     "node": "24.x"
@@ -26,6 +27,8 @@
     "winston": "^3.19.0"
   },
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
+    "@sp-api-sdk/jest": "workspace:*",
     "@tsconfig/node24": "^24.0.4",
     "@types/jsonfile": "^6.1.4",
     "@types/lodash-es": "^4.17.12",

--- a/codegen/tests/utils/rate-limits.spec.ts
+++ b/codegen/tests/utils/rate-limits.spec.ts
@@ -1,0 +1,246 @@
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {type OpenAPIV3} from 'openapi-types'
+
+import {logger} from '../../utils/logger.js'
+import {extractRateLimits} from '../../utils/rate-limits.js'
+
+function buildDocument(paths: OpenAPIV3.PathsObject): OpenAPIV3.Document {
+  return {
+    openapi: '3.0.1',
+    info: {title: 'Selling Partner API', version: 'v0'},
+    paths,
+  }
+}
+
+// The two-column usage plan table Amazon appends to most descriptions
+function usagePlan(rate: string, burst: string) {
+  return [
+    'Does something useful.',
+    '',
+    '**Usage Plan:**',
+    '',
+    '| Rate (requests per second) | Burst |',
+    '| ---- | ---- |',
+    `| ${rate} | ${burst} |`,
+    '',
+    'The `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits.',
+  ].join('\n')
+}
+
+// The three-column form a few older models still use
+function legacyUsagePlan(rate: string, burst: string) {
+  return [
+    'Does something useful.',
+    '',
+    '**Usage Plans:**',
+    '',
+    '| Plan type | Rate (requests per second) | Burst |',
+    '| ---- | ---- | ---- |',
+    `|Default| ${rate} | ${burst} |`,
+    '|Selling partner specific| Variable | Variable |',
+  ].join('\n')
+}
+
+// `urlRegex` is inlined in the generated client as a regular expression
+// literal, so it is a source string here rather than a `RegExp`
+function toRegExp(source: string) {
+  const result = /^\/(?<pattern>.*)\/(?<flags>[a-z]*)$/v.exec(source)
+
+  if (!result?.groups) {
+    throw new Error(`Not a regular expression literal: ${source}`)
+  }
+
+  return new RegExp(result.groups.pattern, result.groups.flags)
+}
+
+describe('extractRateLimits', () => {
+  beforeEach(() => {
+    jest.spyOn(logger, 'info').mockReturnValue(logger)
+    jest.spyOn(logger, 'warn').mockReturnValue(logger)
+  })
+
+  it('should extract the rate and burst of an operation', () => {
+    const document = buildDocument({
+      '/orders/v0/orders': {get: {responses: {}, description: usagePlan('0.0167', '20')}},
+    })
+
+    expect(extractRateLimits(document, 'orders-api-v0')).toStrictEqual([
+      {
+        method: 'get',
+        rate: 0.0167,
+        burst: 20,
+        urlRegex: String.raw`/^\/orders\/v0\/orders$/v`,
+      },
+    ])
+  })
+
+  it('should extract the default plan of a legacy usage plan table', () => {
+    const document = buildDocument({
+      '/definitions/2020-09-01/productTypes': {
+        get: {responses: {}, description: legacyUsagePlan('5', '10')},
+      },
+    })
+
+    expect(extractRateLimits(document, 'product-type-definitions-api-2020-09-01')).toMatchObject([
+      {rate: 5, burst: 10},
+    ])
+  })
+
+  describe('urlRegex', () => {
+    it('should match the pathname of a request to the operation', () => {
+      const document = buildDocument({
+        '/orders/v0/orders/{orderId}/orderItems': {
+          get: {responses: {}, description: usagePlan('0.5', '30')},
+        },
+      })
+
+      const [{urlRegex}] = extractRateLimits(document, 'orders-api-v0')
+      const pattern = toRegExp(urlRegex)
+
+      expect(pattern.test('/orders/v0/orders/902-3159896-1390916/orderItems')).toBe(true)
+      expect(pattern.test('/orders/v0/orders/orderItems')).toBe(false)
+
+      // Anchored, so an endpoint is never matched by a longer pathname
+      expect(pattern.test('/foo/orders/v0/orders/902-3159896-1390916/orderItems')).toBe(false)
+    })
+
+    it('should not let a path parameter swallow the following segments', () => {
+      // `@sp-api-sdk/common` retries with the first matching rate limit, so a
+      // parameter matching across separators would shadow every endpoint
+      // nested under it
+      const document = buildDocument({
+        '/orders/v0/orders/{orderId}': {get: {responses: {}, description: usagePlan('0.5', '30')}},
+        '/orders/v0/orders/{orderId}/orderItems': {
+          get: {responses: {}, description: usagePlan('0.5', '30')},
+        },
+      })
+
+      const [order, orderItems] = extractRateLimits(document, 'orders-api-v0')
+
+      expect(toRegExp(order.urlRegex).test('/orders/v0/orders/902-3159896-1390916')).toBe(true)
+      expect(
+        toRegExp(order.urlRegex).test('/orders/v0/orders/902-3159896-1390916/orderItems'),
+      ).toBe(false)
+      expect(
+        toRegExp(orderItems.urlRegex).test('/orders/v0/orders/902-3159896-1390916/orderItems'),
+      ).toBe(true)
+    })
+
+    it('should escape the literal parts of the path', () => {
+      const document = buildDocument({
+        '/tokens/2021-03-01/restrictedDataToken': {
+          post: {responses: {}, description: usagePlan('1', '10')},
+        },
+      })
+
+      const [{urlRegex}] = extractRateLimits(document, 'tokens-api-2021-03-01')
+      const pattern = toRegExp(urlRegex)
+
+      expect(pattern.test('/tokens/2021-03-01/restrictedDataToken')).toBe(true)
+      expect(pattern.test('/tokens/2021x03x01/restrictedDataToken')).toBe(false)
+    })
+
+    it('should handle several path parameters', () => {
+      const document = buildDocument({
+        '/inbound/fba/2024-03-20/inboundPlans/{inboundPlanId}/shipments/{shipmentId}/boxes': {
+          get: {responses: {}, description: usagePlan('2', '30')},
+        },
+      })
+
+      const [{urlRegex}] = extractRateLimits(document, 'fulfillment-inbound-api-2024-03-20')
+
+      expect(
+        toRegExp(urlRegex).test('/inbound/fba/2024-03-20/inboundPlans/wf1/shipments/sh1/boxes'),
+      ).toBe(true)
+    })
+  })
+
+  it('should keep the operations in the order the model declares them', () => {
+    const document = buildDocument({
+      '/easyShip/2022-03-23/package': {
+        get: {responses: {}, description: usagePlan('1', '5')},
+        post: {responses: {}, description: usagePlan('2', '5')},
+        patch: {responses: {}, description: usagePlan('3', '5')},
+      },
+      '/easyShip/2022-03-23/timeSlot': {post: {responses: {}, description: usagePlan('4', '5')}},
+    })
+
+    const rateLimits = extractRateLimits(document, 'easy-ship-api-2022-03-23')
+
+    expect(rateLimits.map(({method, rate}) => [method, rate])).toStrictEqual([
+      ['get', 1],
+      ['post', 2],
+      ['patch', 3],
+      ['post', 4],
+    ])
+  })
+
+  it('should ignore the keys of a path item that are not operations', () => {
+    const pathItem: OpenAPIV3.PathItemObject & Record<string, unknown> = {
+      parameters: [{name: 'marketplaceIds', in: 'query'}],
+      get: {responses: {}, description: usagePlan('0.0167', '20')},
+      // Amazon extension – an object that could hold a `description` of its own
+      'x-amzn-api-sandbox': {description: usagePlan('99', '99')},
+    }
+
+    const document = buildDocument({'/orders/v0/orders': pathItem})
+
+    expect(extractRateLimits(document, 'orders-api-v0')).toMatchObject([
+      {method: 'get', rate: 0.0167},
+    ])
+  })
+
+  it('should report the operations Amazon documents no usage plan for', () => {
+    const document = buildDocument({
+      '/tax/invoices/2024-06-19/invoices': {get: {responses: {}, description: 'Returns invoices.'}},
+      '/tax/invoices/2024-06-19/exports': {post: {responses: {}}},
+    })
+
+    expect(extractRateLimits(document, 'invoices-api-2024-06-19')).toStrictEqual([])
+    expect(logger.info).toHaveBeenCalledWith('no usage plan documented for 2 operation(s)', {
+      packageName: 'invoices-api-2024-06-19',
+    })
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('should warn about a usage plan it cannot read, naming the operation', () => {
+    const document = buildDocument({
+      '/inbound/fba/2024-03-20/items/prepDetails': {
+        // Amazon publishes placeholders instead of values for some operations
+        get: {responses: {}, description: usagePlan('n', 'n')},
+        post: {responses: {}, description: usagePlan('2', '30')},
+      },
+    })
+
+    expect(extractRateLimits(document, 'fulfillment-inbound-api-2024-03-20')).toMatchObject([
+      {method: 'post', rate: 2, burst: 30},
+    ])
+    expect(logger.warn).toHaveBeenCalledWith(
+      'could not read the usage plan of GET /inbound/fba/2024-03-20/items/prepDetails',
+      {packageName: 'fulfillment-inbound-api-2024-03-20'},
+    )
+  })
+
+  it('should warn rather than stay quiet when the table is reformatted', () => {
+    const description = [
+      'Does something useful.',
+      '',
+      '**Usage Plan:**',
+      '',
+      '| Requests per second | Burst |',
+      '| ---- | ---- |',
+      '| 2 | 6 |',
+    ].join('\n')
+
+    const document = buildDocument({
+      '/orders/v0/orders': {get: {responses: {}, description}},
+    })
+
+    expect(extractRateLimits(document, 'orders-api-v0')).toStrictEqual([])
+    expect(logger.warn).toHaveBeenCalledWith(
+      'could not read the usage plan of GET /orders/v0/orders',
+      {packageName: 'orders-api-v0'},
+    )
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+})

--- a/codegen/utils/rate-limits.ts
+++ b/codegen/utils/rate-limits.ts
@@ -1,0 +1,101 @@
+import {OpenAPIV3} from 'openapi-types'
+
+import {logger} from './logger.js'
+
+const HTTP_METHODS = new Set<string>(Object.values(OpenAPIV3.HttpMethods))
+
+// The usage plan table Amazon documents at the end of every operation
+// description, in either its two-column form or its legacy `|Default|` one
+const RATE_LIMIT_REGEX =
+  /Rate \(requests per second\) \| Burst \|\n(?:\| -{4} )+\|\n(?:\|Default)?\| (?<rate>(?:\d*\.)?\d+) \| (?<burst>(?:\d*\.)?\d+) \|/v
+
+// The heading above the table. Matching on it rather than on the table itself
+// means a usage plan Amazon reformats is reported as unreadable instead of
+// silently counted as undocumented.
+const USAGE_PLAN_MARKER = 'Usage Plan'
+
+export interface RateLimit {
+  method: string
+  rate: number
+  burst: number
+  /** Source of a `v` flagged regular expression, inlined as-is in the client. */
+  urlRegex: string
+}
+
+interface UsagePlans {
+  rateLimits: RateLimit[]
+  /** Operations Amazon documents no usage plan for. */
+  undocumented: string[]
+  /** Operations whose usage plan table could not be read. */
+  unparsable: string[]
+}
+
+// Path parameters stand for a single path segment, so anything but a separator
+// matches. The result is matched against the pathname of a request URL, which
+// is why it is anchored on both ends.
+function buildUrlRegex(path: string) {
+  const source = path
+    .split(/\{[^\{\}]+\}/v)
+    .map((literal) => RegExp.escape(literal))
+    .join(String.raw`[^\/]*`)
+
+  return `/^${source}$/v`
+}
+
+function readPathItemUsagePlans(path: string, pathItem: OpenAPIV3.PathItemObject): UsagePlans {
+  const plans: UsagePlans = {rateLimits: [], undocumented: [], unparsable: []}
+
+  // Walking the document order rather than `OpenAPIV3.HttpMethods` keeps the
+  // generated rate limits in the order Amazon declares its operations
+  for (const key of Object.keys(pathItem)) {
+    // A path item also holds non-operation keys – `parameters` and Amazon's
+    // `x-amzn-api-sandbox` extensions
+    if (!HTTP_METHODS.has(key)) {
+      continue
+    }
+
+    const operation = pathItem[key as OpenAPIV3.HttpMethods]
+    const description = operation?.description ?? ''
+    const result = RATE_LIMIT_REGEX.exec(description)
+
+    if (result?.groups) {
+      plans.rateLimits.push({
+        method: key,
+        rate: Number(result.groups.rate),
+        burst: Number(result.groups.burst),
+        urlRegex: buildUrlRegex(path),
+      })
+    } else if (description.includes(USAGE_PLAN_MARKER)) {
+      plans.unparsable.push(`${key.toUpperCase()} ${path}`)
+    } else {
+      plans.undocumented.push(`${key.toUpperCase()} ${path}`)
+    }
+  }
+
+  return plans
+}
+
+export function extractRateLimits(document: OpenAPIV3.Document, packageName: string): RateLimit[] {
+  const plans = Object.entries(document.paths ?? {}).flatMap(([path, pathItem]) =>
+    pathItem ? [readPathItemUsagePlans(path, pathItem)] : [],
+  )
+
+  const rateLimits = plans.flatMap(({rateLimits}) => rateLimits)
+  const undocumented = plans.flatMap(({undocumented}) => undocumented)
+  const unparsable = plans.flatMap(({unparsable}) => unparsable)
+
+  // Amazon leaves the usage plan out entirely for some operations – there is
+  // nothing to extract, so only the count is worth reporting
+  if (undocumented.length > 0) {
+    logger.info(`no usage plan documented for ${undocumented.length} operation(s)`, {packageName})
+  }
+
+  // A table Amazon does publish but we fail to read means either a format
+  // change or placeholder values – name the operations so a rate limit
+  // silently disappearing is visible in the codegen pull request
+  if (unparsable.length > 0) {
+    logger.warn(`could not read the usage plan of ${unparsable.join(', ')}`, {packageName})
+  }
+
+  return rateLimits
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,12 @@ importers:
         specifier: ^3.19.0
         version: 3.19.0
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1(supports-color@10.2.2)
+      '@sp-api-sdk/jest':
+        specifier: workspace:*
+        version: link:../internal/jest
       '@tsconfig/node24':
         specifier: ^24.0.4
         version: 24.0.4


### PR DESCRIPTION
## Why

Rate limits are parsed out of the usage plan table in each operation description. When that parsing failed, codegen logged `Warning: no rate limiting found for <package>` – no method, no path – and it logged it for *every* operation without a parsable table. Since Amazon documents no usage plan at all for 64 operations, that meant ~70 identical anonymous warnings per run, and a rate limit genuinely disappearing from a model was indistinguishable from the noise.

That is not hypothetical: `GET /inbound/fba/2024-03-20/items/compliance` documents 2 rps / burst 6, but the description has its newlines escaped twice (literal `\n` instead of real ones), so the table never matches and the limit is missing from `fulfillment-inbound-api-2024-03-20`. Its sibling `PUT /items/compliance` does have its entry, which makes the hole easy to miss. That is Amazon's bug to fix upstream – this PR just makes sure we notice it.

## What changed

The two outcomes are now distinct:

- **no usage plan documented at all** – one `info` per client with a count, since there is nothing to act on
- **usage plan present but unreadable** – a `warn` naming each `METHOD /path`

Against the current models that is 15 info lines and exactly one warning:

```
WARN fulfillmentInbound_2024-03-20: could not read the usage plan of
  PUT …/selfShipAppointmentCancellation, GET …/selfShipAppointmentSlots,
  POST …/selfShipAppointmentSlots, POST …/selfShipAppointmentSlots/{slotId}/schedule,
  GET /inbound/fba/2024-03-20/items/compliance, GET /inbound/fba/2024-03-20/items/prepDetails
```

The classification keys off the `Usage Plan` heading rather than the table header, so a table Amazon reformats is reported as unreadable instead of silently counted as undocumented.

Two smaller fixes in the same code:

- only real HTTP methods are walked. The old code cast `Object.keys(pathItem)` to `HttpMethods[]`, so `parameters` and Amazon's `x-amzn-api-sandbox` extensions were walked too – harmless today, but a `description` on that extension object would have produced an entry with `method: 'x-amzn-api-sandbox'`
- dropped a dead `Number.isNaN` guard: the regex only captures digit sequences, so `Number()` could never return `NaN`, and it warned without skipping the entry anyway

## Generated clients are unchanged

Extraction moved to `codegen/utils/rate-limits.ts` so it can be tested without the filesystem or the OpenAPI generator. Document order is preserved, and replaying the new code over a fresh clone of the models yields the same **298** rate limits, byte for byte – no churn in any client.

## Tests

`codegen` had no test setup; this adds one (`jest.config.ts`, a `test` script, `@jest/globals` + `@sp-api-sdk/jest`), picked up by `pnpm test` through Turbo. 11 cases in `codegen/tests/utils/rate-limits.spec.ts` covering rate/burst parsing, the legacy three-column `|Default|` format, document order, non-operation keys, and the two log classifications.

The `urlRegex` cases matter most: it is the one part with no runtime signal at all. If the escaping breaks, the regex still compiles and still gets embedded – it just stops matching the request pathname, silently degrading every 429 retry to the flat 60 s fallback.

I mutation-tested the suite rather than trusting it. Four broken implementations, all caught: dropping the `|Default|` branch, dropping `RegExp.escape`, dropping the method filter, and widening the path parameter from `[^\/]*` to `.*`. That last one initially survived – asserting the regex rejects a *longer* pathname passes anyway because the pattern is anchored. The assertion that actually discriminates is the one modelled on how `@sp-api-sdk/common` uses these: `find()` returns the first match, so an over-broad parameter makes `/orders/v0/orders/{orderId}` shadow `/orders/v0/orders/{orderId}/orderItems`.