### PR TITLE
feat(codegen): list upstream commits in PR bodies

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Create or update clients pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: clients,pnpm-lock.yaml,README.md
+          add-paths: clients,pnpm-lock.yaml,README.md,codegen/clients-upstream-commit.txt
           branch: codegen/update-models
           token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
           title: ${{ steps.commit.outputs.subject }}
@@ -84,7 +84,7 @@ jobs:
       - name: Create or update schemas pull request
         uses: peter-evans/create-pull-request@v8
         with:
-          add-paths: packages/schemas
+          add-paths: packages/schemas,codegen/schemas-upstream-commit.txt
           branch: codegen/update-schemas
           token: ${{ secrets.BOT_GITHUB_TOKEN_PUBLIC }}
           title: ${{ steps.commit.outputs.subject }}

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -81,6 +81,23 @@ Both generators rewrite a list inside a hand-written README, delimited by HTML c
 
 Anything between the markers is replaced on every run; the surrounding prose is left alone. A missing marker fails the run rather than silently leaving a stale list behind.
 
+### Pull request body and commit message
+
+Each generator writes the body and commit message its workflow hands to `create-pull-request`, reporting what the run added, removed and updated:
+
+| Generator | Body                 | Commit message               | Upstream commit               |
+| --------- | -------------------- | ---------------------------- | ----------------------------- |
+| Clients   | `clients-pr-body.md` | `clients-commit-message.txt` | `clients-upstream-commit.txt` |
+| Schemas   | `schemas-pr-body.md` | `schemas-commit-message.txt` | `schemas-upstream-commit.txt` |
+
+The bodies and commit messages are workflow artifacts and gitignored. The upstream commit files are not: they are committed, and hold the commit of [selling-partner-api-models](https://github.com/amzn/selling-partner-api-models) the checked-in output was generated from.
+
+Amazon's models are not vendored here, so the diff of a codegen pull request shows the generated output only. The recorded commit closes that gap – every run lists the upstream commits touching `models` (or `schemas`) since it at the top of the body. Because the file is read from the base branch, an open pull request always lists everything it brings in, however many runs updated it.
+
+Each commit is written as `amzn/selling-partner-api-models@<sha>`, the form GitHub records as a reference to the commit rather than as a plain link to it. Subjects are quoted verbatim, with `#` and `@` escaped so that an upstream subject cannot autolink an unrelated issue of this repository or notify a stranger.
+
+A run only records a new commit when the generated output actually moved; bumping it on its own would open a pull request whose whole diff is a commit hash. If the recorded commit is missing or unknown to the clone – a first run, or an upstream force-push – the section is left out and the run carries on.
+
 ## Patches
 
 JSON patches (RFC 6902) can fix invalid or incomplete OpenAPI specs before generation.

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -96,7 +96,7 @@ Amazon's models are not vendored here, so the diff of a codegen pull request sho
 
 Each commit is written as `amzn/selling-partner-api-models@<sha>`, the form GitHub records as a reference to the commit rather than as a plain link to it. Subjects are quoted verbatim, with `#` and `@` escaped so that an upstream subject cannot autolink an unrelated issue of this repository or notify a stranger.
 
-A run only records a new commit when the generated output actually moved; bumping it on its own would open a pull request whose whole diff is a commit hash. If the recorded commit is missing or unknown to the clone – a first run, or an upstream force-push – the section is left out and the run carries on.
+A run only records a new commit when the generated output actually moved; bumping it on its own would open a pull request whose whole diff is a commit hash. If the recorded commit is missing, unknown to the clone or not a commit hash at all – a first run, an upstream force-push, a hand edit – the section is left out and the run carries on.
 
 ## Patches
 

--- a/codegen/clients-upstream-commit.txt
+++ b/codegen/clients-upstream-commit.txt
@@ -1,0 +1,1 @@
+af0be99a754fba53d46d6a845a5aba8f99f077c4

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -17,6 +17,7 @@ import {logger} from './utils/logger.js'
 import {applyPatches} from './utils/patch.js'
 import {
   buildSection,
+  buildUpstreamSection,
   formatDate,
   writeCommitMessage,
   writePullRequestBody,
@@ -26,11 +27,18 @@ import {replaceReadmeSection} from './utils/readme.js'
 import {renderTemplate} from './utils/render-template.js'
 import {runCommand} from './utils/run-command.js'
 import {replaceAllTags} from './utils/tags.js'
+import {
+  getUpstreamCommits,
+  getUpstreamHead,
+  readUpstreamCommit,
+  writeUpstreamCommit,
+} from './utils/upstream.js'
 
 const GRANTLESS_APIS = [{name: 'notifications-api-v1', scope: 'NOTIFICATIONS'}]
 
 const CLIENTS_PR_BODY_PATH = 'codegen/clients-pr-body.md'
 const CLIENTS_COMMIT_MESSAGE_PATH = 'codegen/clients-commit-message.txt'
+const CLIENTS_UPSTREAM_COMMIT_PATH = 'codegen/clients-upstream-commit.txt'
 const ROOT_README_PATH = 'README.md'
 
 interface ClientInfo {
@@ -300,7 +308,14 @@ export async function writeClientsPullRequest({added, removed}: ClientsDiff) {
   const scoped = (packageNames: string[]) =>
     packageNames.map((packageName) => `@sp-api-sdk/${packageName}`)
 
+  const upstream = {
+    pathspec: 'models',
+    from: await readUpstreamCommit(CLIENTS_UPSTREAM_COMMIT_PATH),
+    to: await getUpstreamHead(),
+  }
+
   await writePullRequestBody(CLIENTS_PR_BODY_PATH, [
+    ...buildUpstreamSection(await getUpstreamCommits(upstream), upstream),
     ...buildSection(
       'New clients',
       'These packages do not exist on npm yet – initialize them before the next release:',
@@ -321,6 +336,15 @@ export async function writeClientsPullRequest({added, removed}: ClientsDiff) {
       ? `Amazon no longer publishes a model for ${scoped(removed).join(', ')}, so ${removed.length > 1 ? 'those packages were' : 'that package was'} removed from the SDK.`
       : undefined,
   )
+
+  // Only recorded when the generated output actually moved: bumping it on its
+  // own would open a pull request whose whole diff is a commit hash, for an
+  // upstream change that generates identical clients. Leaving it behind is
+  // harmless – the next run that does change something reports every upstream
+  // commit since the recorded one.
+  if (added.length > 0 || removed.length > 0 || changed.length > 0) {
+    await writeUpstreamCommit(CLIENTS_UPSTREAM_COMMIT_PATH, upstream.to)
+  }
 }
 
 async function updateRootReadmeClientsList(clients: ClientInfo[]) {

--- a/codegen/generate-schemas.ts
+++ b/codegen/generate-schemas.ts
@@ -11,14 +11,22 @@ import {getChangedPaths} from './utils/git.js'
 import {logger} from './utils/logger.js'
 import {
   buildSection,
+  buildUpstreamSection,
   formatDate,
   writeCommitMessage,
   writePullRequestBody,
 } from './utils/pull-request.js'
 import {replaceReadmeSection} from './utils/readme.js'
+import {
+  getUpstreamCommits,
+  getUpstreamHead,
+  readUpstreamCommit,
+  writeUpstreamCommit,
+} from './utils/upstream.js'
 
 const SCHEMAS_PR_BODY_PATH = 'codegen/schemas-pr-body.md'
 const SCHEMAS_COMMIT_MESSAGE_PATH = 'codegen/schemas-commit-message.txt'
+const SCHEMAS_UPSTREAM_COMMIT_PATH = 'codegen/schemas-upstream-commit.txt'
 const SCHEMAS_README_PATH = 'packages/schemas/README.md'
 
 interface SchemaFile {
@@ -303,7 +311,14 @@ export async function writeSchemasPullRequest({added, removed}: SchemasDiff) {
     .filter((schemaName) => !reported.has(schemaName))
     .toSorted()
 
+  const upstream = {
+    pathspec: 'schemas',
+    from: await readUpstreamCommit(SCHEMAS_UPSTREAM_COMMIT_PATH),
+    to: await getUpstreamHead(),
+  }
+
   await writePullRequestBody(SCHEMAS_PR_BODY_PATH, [
+    ...buildUpstreamSection(await getUpstreamCommits(upstream), upstream),
     ...buildSection('New schemas', 'These schemas are newly exported:', added),
     ...buildSection(
       'Removed schemas',
@@ -320,4 +335,11 @@ export async function writeSchemasPullRequest({added, removed}: SchemasDiff) {
       ? `Amazon no longer publishes ${removed.join(', ')}, so ${removed.length > 1 ? 'those schemas and their exports were' : 'that schema and its export was'} removed from \`@sp-api-sdk/schemas\`.`
       : undefined,
   )
+
+  // Same as for the clients – recorded only when the generated output moved,
+  // so that an upstream change generating identical schemas does not open a
+  // pull request holding nothing but a commit hash.
+  if (added.length > 0 || removed.length > 0 || changed.length > 0) {
+    await writeUpstreamCommit(SCHEMAS_UPSTREAM_COMMIT_PATH, upstream.to)
+  }
 }

--- a/codegen/schemas-upstream-commit.txt
+++ b/codegen/schemas-upstream-commit.txt
@@ -1,0 +1,1 @@
+af0be99a754fba53d46d6a845a5aba8f99f077c4

--- a/codegen/tests/utils/pull-request.spec.ts
+++ b/codegen/tests/utils/pull-request.spec.ts
@@ -1,0 +1,69 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {buildUpstreamSection} from '../../utils/pull-request.js'
+
+const PREVIOUS_SHA = '185fbc8666d1a8ab4bbbcbc4b1b47c7d3b6dbb0e'
+const SHA = 'af0be99a754fba53d46d6a845a5aba8f99f077c4'
+
+const RANGE = {pathspec: 'models', from: PREVIOUS_SHA, to: SHA}
+
+describe('buildUpstreamSection', () => {
+  it('lists the commits, linked to the upstream repository', () => {
+    const [heading, description, list] = buildUpstreamSection(
+      [
+        {sha: SHA, subject: 'Update Finances model'},
+        {sha: PREVIOUS_SHA, subject: 'Update Fulfillment Outbound'},
+      ],
+      RANGE,
+    )
+
+    expect(heading).toBe('### Upstream commits')
+    expect(description).toBe(
+      `[2 commits](https://github.com/amzn/selling-partner-api-models/compare/${PREVIOUS_SHA}...${SHA}) touched \`models\` since the last update:`,
+    )
+    // `owner/repo@sha` – the form GitHub records as a reference on the commit
+    expect(list).toBe(
+      [
+        `- amzn/selling-partner-api-models@${SHA} Update Finances model`,
+        `- amzn/selling-partner-api-models@${PREVIOUS_SHA} Update Fulfillment Outbound`,
+      ].join('\n'),
+    )
+  })
+
+  it('counts a single commit in the singular', () => {
+    const [, description] = buildUpstreamSection([{sha: SHA, subject: 'Update Finances'}], RANGE)
+
+    expect(description).toContain('[1 commit](')
+  })
+
+  it('names the path the generator reads', () => {
+    const [, description] = buildUpstreamSection([{sha: SHA, subject: 'Model updates'}], {
+      ...RANGE,
+      pathspec: 'schemas',
+    })
+
+    expect(description).toContain('touched `schemas`')
+  })
+
+  // Rendered as-is, they would cross-reference an issue of this repository or
+  // notify an unrelated user
+  it('escapes what GitHub would autolink in a subject', () => {
+    const section = buildUpstreamSection([{sha: SHA, subject: 'Fix #123 by @someone'}], RANGE)
+
+    expect(section.at(-1)).toContain(String.raw`Fix \#123 by \@someone`)
+  })
+
+  it('is left out when there is nothing to report', () => {
+    expect(buildUpstreamSection([], RANGE)).toStrictEqual([])
+  })
+
+  // Nothing has been recorded yet – there is no range to compare against
+  it('is left out when the previous commit is unknown', () => {
+    expect(
+      buildUpstreamSection([{sha: SHA, subject: 'Update Finances model'}], {
+        ...RANGE,
+        from: undefined,
+      }),
+    ).toStrictEqual([])
+  })
+})

--- a/codegen/tests/utils/upstream.spec.ts
+++ b/codegen/tests/utils/upstream.spec.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it} from '@jest/globals'
+
+import {parseCommitLog} from '../../utils/upstream.js'
+
+const SHA = 'af0be99a754fba53d46d6a845a5aba8f99f077c4'
+const OTHER_SHA = '185fbc8666d1a8ab4bbbcbc4b1b47c7d3b6dbb0e'
+
+describe('parseCommitLog', () => {
+  it('reads the `<sha>\\t<subject>` lines git log prints', () => {
+    const log = [`${SHA}\tUpdate Finances model`, `${OTHER_SHA}\tUpdate Fulfillment Outbound`].join(
+      '\n',
+    )
+
+    expect(parseCommitLog(log)).toStrictEqual([
+      {sha: SHA, subject: 'Update Finances model'},
+      {sha: OTHER_SHA, subject: 'Update Fulfillment Outbound'},
+    ])
+  })
+
+  it('keeps tabs inside a subject', () => {
+    expect(parseCommitLog(`${SHA}\tUpdate\tFinances model`)).toStrictEqual([
+      {sha: SHA, subject: 'Update\tFinances model'},
+    ])
+  })
+
+  it('returns nothing for an empty log', () => {
+    expect(parseCommitLog('')).toStrictEqual([])
+    expect(parseCommitLog('\n')).toStrictEqual([])
+  })
+
+  it('ignores lines that are not a commit', () => {
+    expect(parseCommitLog(`warning: something\n${SHA}\tUpdate Finances model`)).toStrictEqual([
+      {sha: SHA, subject: 'Update Finances model'},
+    ])
+  })
+})

--- a/codegen/tests/utils/upstream.spec.ts
+++ b/codegen/tests/utils/upstream.spec.ts
@@ -1,9 +1,47 @@
-import {describe, expect, it} from '@jest/globals'
+import {beforeEach, describe, expect, it, jest} from '@jest/globals'
 
-import {parseCommitLog} from '../../utils/upstream.js'
+import {logger} from '../../utils/logger.js'
+import {getUpstreamCommits, parseCommitLog, parseUpstreamCommit} from '../../utils/upstream.js'
 
 const SHA = 'af0be99a754fba53d46d6a845a5aba8f99f077c4'
 const OTHER_SHA = '185fbc8666d1a8ab4bbbcbc4b1b47c7d3b6dbb0e'
+
+describe('parseUpstreamCommit', () => {
+  it('reads a recorded commit, however it was written', () => {
+    expect(parseUpstreamCommit(`${SHA}\n`)).toBe(SHA)
+    expect(parseUpstreamCommit(`  ${SHA}  `)).toBe(SHA)
+  })
+
+  // Whatever it holds would otherwise reach a shell command
+  it('refuses anything that is not a commit hash', () => {
+    expect(parseUpstreamCommit('')).toBeUndefined()
+    expect(parseUpstreamCommit('HEAD')).toBeUndefined()
+    expect(parseUpstreamCommit(SHA.slice(0, 7))).toBeUndefined()
+    expect(parseUpstreamCommit(`${SHA} -- .`)).toBeUndefined()
+    expect(parseUpstreamCommit(`${SHA}; echo pwned`)).toBeUndefined()
+  })
+})
+
+describe('getUpstreamCommits', () => {
+  beforeEach(() => {
+    jest.spyOn(logger, 'warn').mockReturnValue(logger)
+  })
+
+  it('reports nothing when no commit was recorded', async () => {
+    await expect(
+      getUpstreamCommits({pathspec: 'models', from: undefined, to: SHA}),
+    ).resolves.toStrictEqual([])
+  })
+
+  // Dropped before it reaches git, so no command fails and nothing is logged
+  it('reports nothing for a recorded commit that is not a hash', async () => {
+    await expect(
+      getUpstreamCommits({pathspec: 'models', from: 'HEAD~1; echo pwned', to: SHA}),
+    ).resolves.toStrictEqual([])
+
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+})
 
 describe('parseCommitLog', () => {
   it('reads the `<sha>\\t<subject>` lines git log prints', () => {

--- a/codegen/utils/pull-request.ts
+++ b/codegen/utils/pull-request.ts
@@ -1,7 +1,14 @@
 import fs from 'node:fs/promises'
 
+import {
+  UPSTREAM_REPOSITORY,
+  UPSTREAM_URL,
+  type UpstreamCommit,
+  type UpstreamRange,
+} from './upstream.js'
+
 const INTRO = [
-  'This is an automated pull request that was generated due to changes detected in the [Amazon Selling Partner API models](https://github.com/amzn/selling-partner-api-models).',
+  `This is an automated pull request that was generated due to changes detected in the [Amazon Selling Partner API models](${UPSTREAM_URL}).`,
   'The branch associated with this PR will be automatically updated if other changes occur.',
 ]
 
@@ -39,6 +46,39 @@ export function buildSection(heading: string, description: string, items: string
   }
 
   return [`### ${heading}`, description, items.map((item) => `- \`${item}\``).join('\n')]
+}
+
+// Upstream subjects are quoted verbatim, and a `#123` or `@handle` in one would
+// otherwise autolink – cross-referencing an unrelated issue of this repository,
+// or notifying whoever owns that handle.
+function escapeAutolinks(subject: string) {
+  return subject.replaceAll(/[#@]/gv, (character) => `\\${character}`)
+}
+
+// Amazon's models are not vendored in this repository, so the diff of a codegen
+// pull request only shows the generated output – the upstream commits behind it
+// are listed here, to be reviewed alongside.
+//
+// Each is written as `owner/repo@sha` rather than as a link to it: that is the
+// form GitHub treats as a reference to the commit, not merely a URL pointing at
+// one.
+export function buildUpstreamSection(
+  commits: UpstreamCommit[],
+  {pathspec, from, to}: UpstreamRange,
+) {
+  if (commits.length === 0 || from === undefined) {
+    return []
+  }
+
+  const count = `${commits.length} ${commits.length === 1 ? 'commit' : 'commits'}`
+
+  return [
+    '### Upstream commits',
+    `[${count}](${UPSTREAM_URL}/compare/${from}...${to}) touched \`${pathspec}\` since the last update:`,
+    commits
+      .map(({sha, subject}) => `- ${UPSTREAM_REPOSITORY}@${sha} ${escapeAutolinks(subject)}`)
+      .join('\n'),
+  ]
 }
 
 // Consumed by the codegen workflow, which hands the file to `create-pull-request`

--- a/codegen/utils/upstream.ts
+++ b/codegen/utils/upstream.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises'
+
+import {logger} from './logger.js'
+import {runCommand} from './run-command.js'
+
+export const UPSTREAM_REPOSITORY = 'amzn/selling-partner-api-models'
+export const UPSTREAM_URL = `https://github.com/${UPSTREAM_REPOSITORY}`
+
+// Where `generate.ts` clones the models repository
+const UPSTREAM_PATH = 'selling-partner-api-models'
+
+// `<sha>\t<subject>` lines, as printed by `git log --format=%H%x09%s`
+const COMMIT_REGEX = /^(?<sha>[\da-f]{40})\t(?<subject>.*)$/v
+
+export interface UpstreamCommit {
+  sha: string
+  subject: string
+}
+
+export interface UpstreamRange {
+  /** Path in the models repository the generator reads. */
+  pathspec: string
+  /** Recorded commit the checked-in output was generated from, if any. */
+  from: string | undefined
+  /** Commit the clone is at. */
+  to: string
+}
+
+// The upstream commit the generated code was built from, committed to this
+// repository. Amazon's models are not vendored here, so it is the only way to
+// tell which upstream changes a pull request brings in.
+export async function readUpstreamCommit(path: string) {
+  try {
+    const contents = await fs.readFile(path, 'utf8')
+    const sha = contents.trim()
+
+    return sha.length > 0 ? sha : undefined
+  } catch {
+    // Not recorded yet – the first run against a generator reports no commits
+    // and records one for the next.
+    return undefined
+  }
+}
+
+export async function writeUpstreamCommit(path: string, sha: string) {
+  await fs.writeFile(path, `${sha}\n`)
+}
+
+export async function getUpstreamHead() {
+  const {stdout} = await runCommand(`git -C ${UPSTREAM_PATH} rev-parse HEAD`, {quiet: true})
+
+  return stdout.trim()
+}
+
+export function parseCommitLog(log: string): UpstreamCommit[] {
+  return log
+    .split('\n')
+    .map((line) => {
+      const result = COMMIT_REGEX.exec(line)
+
+      return result?.groups
+        ? {sha: result.groups.sha, subject: result.groups.subject.trim()}
+        : undefined
+    })
+    .filter((commit) => commit !== undefined)
+}
+
+// Upstream commits touching `pathspec` over the range, newest first. Merge
+// commits are left out – they carry no content of their own.
+export async function getUpstreamCommits({
+  pathspec,
+  from,
+  to,
+}: UpstreamRange): Promise<UpstreamCommit[]> {
+  if (from === undefined || from === to) {
+    return []
+  }
+
+  try {
+    const {stdout} = await runCommand(
+      `git -C ${UPSTREAM_PATH} log --no-merges --format=%H%x09%s ${from}..${to} -- ${pathspec}`,
+      {quiet: true},
+    )
+
+    return parseCommitLog(stdout)
+  } catch (error) {
+    // The recorded commit is unknown to the clone – upstream rewrote its
+    // history. Not worth failing the generation over: the pull request goes
+    // without the section, and this run records a commit that resolves again.
+    logger.warn(`Could not list upstream commits since ${from}: ${String(error)}`)
+
+    return []
+  }
+}

--- a/codegen/utils/upstream.ts
+++ b/codegen/utils/upstream.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 
+import {isNodeError} from './error.js'
 import {logger} from './logger.js'
 import {runCommand} from './run-command.js'
 
@@ -11,6 +12,8 @@ const UPSTREAM_PATH = 'selling-partner-api-models'
 
 // `<sha>\t<subject>` lines, as printed by `git log --format=%H%x09%s`
 const COMMIT_REGEX = /^(?<sha>[\da-f]{40})\t(?<subject>.*)$/v
+
+const COMMIT_SHA_REGEX = /^[\da-f]{40}$/v
 
 export interface UpstreamCommit {
   sha: string
@@ -26,20 +29,39 @@ export interface UpstreamRange {
   to: string
 }
 
+// A commit hash on its own, as `writeUpstreamCommit` records it. Anything else
+// – a hand edit, a truncated write – is refused rather than handed to git.
+export function parseUpstreamCommit(contents: string) {
+  const sha = contents.trim()
+
+  return COMMIT_SHA_REGEX.test(sha) ? sha : undefined
+}
+
 // The upstream commit the generated code was built from, committed to this
 // repository. Amazon's models are not vendored here, so it is the only way to
 // tell which upstream changes a pull request brings in.
 export async function readUpstreamCommit(path: string) {
-  try {
-    const contents = await fs.readFile(path, 'utf8')
-    const sha = contents.trim()
+  let contents: string
 
-    return sha.length > 0 ? sha : undefined
-  } catch {
-    // Not recorded yet – the first run against a generator reports no commits
-    // and records one for the next.
-    return undefined
+  try {
+    contents = await fs.readFile(path, 'utf8')
+  } catch (error: unknown) {
+    if (isNodeError(error, Error) && error.code === 'ENOENT') {
+      // Not recorded yet – the first run for a generator reports no commits
+      // and records one for the next.
+      return undefined
+    }
+
+    throw error
   }
+
+  const sha = parseUpstreamCommit(contents)
+
+  if (sha === undefined) {
+    logger.warn(`Ignoring ${path}: it does not hold a commit hash`)
+  }
+
+  return sha
 }
 
 export async function writeUpstreamCommit(path: string, sha: string) {
@@ -48,8 +70,15 @@ export async function writeUpstreamCommit(path: string, sha: string) {
 
 export async function getUpstreamHead() {
   const {stdout} = await runCommand(`git -C ${UPSTREAM_PATH} rev-parse HEAD`, {quiet: true})
+  const sha = stdout.trim()
 
-  return stdout.trim()
+  // Everything is generated from this clone, so a head that cannot be read
+  // discredits the whole run, not just this section of the body
+  if (!COMMIT_SHA_REGEX.test(sha)) {
+    throw new Error(`Could not read the head of the ${UPSTREAM_PATH} clone: ${sha}`)
+  }
+
+  return sha
 }
 
 export function parseCommitLog(log: string): UpstreamCommit[] {
@@ -72,7 +101,11 @@ export async function getUpstreamCommits({
   from,
   to,
 }: UpstreamRange): Promise<UpstreamCommit[]> {
-  if (from === undefined || from === to) {
+  // The range is interpolated into a shell command, and `from` reaches here
+  // from a file in the repository – nothing but a commit hash goes through.
+  // `to` is checked where it is read, and `pathspec` is a constant of the
+  // generator calling in.
+  if (from === undefined || from === to || !COMMIT_SHA_REGEX.test(from)) {
     return []
   }
 


### PR DESCRIPTION
The codegen pull requests show the generated output only. Amazon's models are not vendored here, so nothing in the diff says which upstream changes caused it — you have to go read amzn/selling-partner-api-models yourself to find out.

Each generator now records the models commit it was built from, and lists the upstream commits since it at the top of the pull request body:

> ### Upstream commits
>
> [11 commits](https://github.com/amzn/selling-partner-api-models/compare/96d516badc8d69a566a4160e3c7b315600e043a7...af0be99a754fba53d46d6a845a5aba8f99f077c4) touched `models` since the last update:
>
> - amzn/selling-partner-api-models@af0be99a754fba53d46d6a845a5aba8f99f077c4 Update Finances description
> - amzn/selling-partner-api-models@c47d23c725a534819c9d2094e2877336e44ed81e Fix link
> - amzn/selling-partner-api-models@51695028c3b85151569fcb116a9b2f65185b830f Update burst values in Transfers model
> - …

Each commit is written as `amzn/selling-partner-api-models@<sha>` rather than as a markdown link, so that GitHub records it as a reference to the commit. The list is scoped to the path the generator reads — `models` for the clients, `schemas` for the schemas — and leaves out merge commits.

## How the range is resolved

`codegen/clients-upstream-commit.txt` and `codegen/schemas-upstream-commit.txt` hold the commit each generator's checked-in output was generated from. They are committed, unlike the pull request bodies and commit messages next to them, and were seeded with the commit the current output was generated from.

Because the file is read from the base branch, an open codegen pull request always lists everything it brings in, however many runs refreshed the branch.

A run only records a new commit when the generated output actually moved — bumping it on its own would open a pull request whose whole diff is a hash, for an upstream change that generates identical code. A recorded commit the clone does not know (an upstream force-push) drops the section with a warning rather than failing the run.

## Notes

- Subjects are quoted verbatim with `#` and `@` escaped, so an upstream subject cannot cross-reference an unrelated issue here or notify a stranger
- The compare link covers the whole upstream range, not just `models` / `schemas` — GitHub compare URLs take no path filter
- The pure parts (`parseCommitLog`, `buildUpstreamSection`) are covered by tests