### PR TITLE
feat(codegen): note sandbox-only operations

### DIFF
--- a/clients/fba-inventory-api-v1/README.md
+++ b/clients/fba-inventory-api-v1/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fba-inventory-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/fba-inventory-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** Sandbox-only operations, unavailable in production: `createInventoryItem`, `deleteInventoryItem`, `addInventory`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
 The Selling Partner API for FBA Inventory lets you programmatically retrieve information about inventory in Amazon's fulfillment network.
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)

--- a/clients/fulfillment-outbound-api-2020-07-01/README.md
+++ b/clients/fulfillment-outbound-api-2020-07-01/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fulfillment-outbound-api-2020-07-01)](https://www.npmjs.com/package/@sp-api-sdk/fulfillment-outbound-api-2020-07-01)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** Sandbox-only operations, unavailable in production: `submitFulfillmentOrderStatusUpdate`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
 The Selling Partner API for Fulfillment Outbound lets you create applications that help a seller fulfill Multi-Channel Fulfillment orders using their inventory in Amazon's fulfillment network. You can get information on both potential and existing fulfillment orders.
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)

--- a/clients/fulfillment-outbound-api-2026-07-04/README.md
+++ b/clients/fulfillment-outbound-api-2026-07-04/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/fulfillment-outbound-api-2026-07-04)](https://www.npmjs.com/package/@sp-api-sdk/fulfillment-outbound-api-2026-07-04)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** Sandbox-only operations, unavailable in production: `updateOrderStatus`, `updatePackage`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
 The Selling Partner API for Fulfillment Outbound lets you create applications that help a seller fulfill Multi-Channel Fulfillment orders using their inventory in Amazon's fulfillment network. You can get information on both potential and existing fulfillment orders.
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)

--- a/clients/notifications-api-v1/README.md
+++ b/clients/notifications-api-v1/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/notifications-api-v1)](https://www.npmjs.com/package/@sp-api-sdk/notifications-api-v1)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** Sandbox-only operations, unavailable in production: `sendTestNotification`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
 The Selling Partner API for Notifications lets you subscribe to notifications that are relevant to a selling partner's business. Using this API you can create a destination to receive notifications, subscribe to notifications, delete notification subscriptions, and more.
 
 For more information, refer to the [Notifications Use Case Guide](https://developer-docs.amazon.com/sp-api/docs/notifications-api-v1-use-case-guide).

--- a/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
+++ b/clients/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://img.shields.io/npm/v/@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28)](https://www.npmjs.com/package/@sp-api-sdk/vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28)
 [![XO code style](https://img.shields.io/badge/code_style-xo-cyan)](https://github.com/xojs/xo)
 
+> **Note:** Sandbox-only operations, unavailable in production: `generateOrderScenarios`, `getOrderScenarios`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
 The Selling Partner API for Vendor Direct Fulfillment Sandbox Test Data provides programmatic access to vendor direct fulfillment sandbox test data.
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)

--- a/codegen/generate-clients.ts
+++ b/codegen/generate-clients.ts
@@ -51,6 +51,38 @@ interface ClientsDiff {
   removed: string[]
 }
 
+// Amazon marks the operations that only exist in the sandbox, either on the
+// path item – applying to every one of its operations – or on the operation
+// itself. Both placements are in use upstream.
+const SANDBOX_ONLY_EXTENSION = 'x-amzn-api-sandbox-only'
+
+function isSandboxOnly(node: OpenAPIV3.PathItemObject | OpenAPIV3.OperationObject): boolean {
+  return (node as Record<string, unknown>)[SANDBOX_ONLY_EXTENSION] === true
+}
+
+// Operation ids of the operations Amazon serves in the sandbox only. Calling
+// one against a production endpoint fails, and nothing in the generated client
+// tells them apart from the rest, hence the note in the client README.
+function getSandboxOnlyOperations(document: OpenAPIV3.Document): string[] {
+  const operationIds: string[] = []
+
+  for (const pathItem of Object.values(document.paths ?? {})) {
+    if (!pathItem) {
+      continue
+    }
+
+    for (const method of Object.values(OpenAPIV3.HttpMethods)) {
+      const operation = pathItem[method]
+
+      if (operation?.operationId && (isSandboxOnly(pathItem) || isSandboxOnly(operation))) {
+        operationIds.push(operation.operationId)
+      }
+    }
+  }
+
+  return operationIds
+}
+
 function hasDeprecatedOperations(document: OpenAPIV3.Document): boolean {
   for (const pathItem of Object.values(document.paths ?? {})) {
     if (!pathItem) {
@@ -226,6 +258,7 @@ async function generateClientVersion(modelFilePath: string): Promise<ClientInfo>
     }),
   )
   const isDeprecated = hasDeprecatedOperations(document)
+  const sandboxOnlyOperations = getSandboxOnlyOperations(document)
 
   await fs.writeFile(
     `${clientDirectoryPath}/README.md`,
@@ -236,6 +269,9 @@ async function generateClientVersion(modelFilePath: string): Promise<ClientInfo>
       sdkClientDocUrl: `https://bizon.github.io/selling-partner-api-sdk/modules/_sp-api-sdk_${packageName}.html`,
       grantlessScope: grantlessInfo?.scope,
       hasDeprecatedOperations: isDeprecated,
+      sandboxOnlyOperations: sandboxOnlyOperations
+        .map((operationId) => `\`${operationId}\``)
+        .join(', '),
     }),
   )
 

--- a/codegen/templates/README.md.mustache
+++ b/codegen/templates/README.md.mustache
@@ -7,6 +7,10 @@
 > **Note:** This client contains deprecated operations. Refer to the [SP-API Deprecations Schedule](https://developer-docs.amazon.com/sp-api/docs/sp-api-deprecations) for more information.
 
 {{/hasDeprecatedOperations}}
+{{#sandboxOnlyOperations}}
+> **Note:** Sandbox-only operations, unavailable in production: {{.}}. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.
+
+{{/sandboxOnlyOperations}}
 {{description}}
 
 [<img src="https://files.bizon.solutions/images/logo/bizon-horizontal.png" alt="Bizon" width="250"/>](https://www.bizon.solutions?utm_source=github&utm_medium=readme&utm_campaign=selling-partner-api-sdk)


### PR DESCRIPTION
Amazon marks the operations it serves only in the sandbox with the `x-amzn-api-sandbox-only` extension. We ignored it, so those operations appeared in the generated clients like any other — calling one against a production endpoint fails.

Codegen now reads the extension and lists the affected operations in a note at the top of the client README, alongside the existing deprecation note. The extension is set at path-item level upstream (7 operations) and at operation level (2), so both placements are checked.

Nine operations across five clients are affected:

| client | operations |
| --- | --- |
| `fba-inventory-api-v1` | `createInventoryItem`, `deleteInventoryItem`, `addInventory` |
| `fulfillment-outbound-api-2020-07-01` | `submitFulfillmentOrderStatusUpdate` |
| `fulfillment-outbound-api-2026-07-04` | `updateOrderStatus`, `updatePackage` |
| `notifications-api-v1` | `sendTestNotification` |
| `vendor-direct-fulfillment-sandbox-test-data-api-2021-10-28` | `generateOrderScenarios`, `getOrderScenarios` |

The rendered note looks like this:

> **Note:** Sandbox-only operations, unavailable in production: `createInventoryItem`, `deleteInventoryItem`, `addInventory`. Refer to the [Selling Partner API sandbox](https://developer-docs.amazon.com/sp-api/docs/the-selling-partner-api-sandbox) documentation for more information.

Amazon's documentation agrees with the extension. Seven of the nine operations state it in their own description — for instance [`updateOrderStatus`](https://developer-docs.amazon.com/sp-api/reference/updateorderstatus): *"This is a sandbox-only operation and must be directed to a sandbox endpoint."* The two Vendor Direct Fulfillment Sandbox Test Data operations do not repeat it in prose, but that model is the only one of the 66 that declares `sandbox.sellingpartnerapi-na.amazon.com` as its host — the whole API is sandbox-only by declaration.

Operation ids are not unique across APIs, and the extraction is scoped per model: `externalFulfillmentShipments_2024-09-11` has its own `updatePackage`, which is not sandbox-only and is correctly left alone.

The root README client list is untouched. Its `— contains deprecated operations` suffix warns about a whole client, whereas sandbox-only is a per-operation detail on clients that are otherwise fine to use.
